### PR TITLE
fix: replace ContentSlot with MDCSlot for Nuxt Content v3

### DIFF
--- a/components/content/LandingFeature.vue
+++ b/components/content/LandingFeature.vue
@@ -14,7 +14,7 @@ defineProps<{
       {{ title }}
     </h3>
     <p class="mt-2 text-sm text-muted">
-      <ContentSlot />
+      <MDCSlot :use="$slots.default" />
     </p>
   </div>
 </template>

--- a/components/content/LandingFeatures.vue
+++ b/components/content/LandingFeatures.vue
@@ -11,7 +11,7 @@ defineProps<{
     <UContainer>
       <LandingSectionHeader :headline="headline" :title="title" :description="description" />
       <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        <ContentSlot />
+        <MDCSlot :use="$slots.default" />
       </div>
     </UContainer>
   </section>

--- a/components/content/LandingReferences.vue
+++ b/components/content/LandingReferences.vue
@@ -11,7 +11,7 @@ defineProps<{
     <UContainer>
       <LandingSectionHeader :headline="headline" :title="title" :description="description" />
       <div class="mt-12">
-        <ContentSlot />
+        <MDCSlot :use="$slots.default" />
       </div>
     </UContainer>
   </section>

--- a/components/content/LandingStep.vue
+++ b/components/content/LandingStep.vue
@@ -16,7 +16,7 @@ defineProps<{
       {{ title }}
     </h3>
     <p class="mt-2 text-sm text-muted">
-      <ContentSlot />
+      <MDCSlot :use="$slots.default" />
     </p>
   </div>
 </template>

--- a/components/content/LandingSteps.vue
+++ b/components/content/LandingSteps.vue
@@ -11,7 +11,7 @@ defineProps<{
     <UContainer>
       <LandingSectionHeader :headline="headline" :title="title" :description="description" />
       <div class="mt-12 grid gap-8 sm:grid-cols-3">
-        <ContentSlot />
+        <MDCSlot :use="$slots.default" />
       </div>
     </UContainer>
   </section>

--- a/components/content/LandingUseCase.vue
+++ b/components/content/LandingUseCase.vue
@@ -7,6 +7,6 @@ defineProps<{
 
 <template>
   <LandingFeature :icon="icon" :title="title">
-    <ContentSlot />
+    <MDCSlot :use="$slots.default" />
   </LandingFeature>
 </template>

--- a/components/content/LandingUseCases.vue
+++ b/components/content/LandingUseCases.vue
@@ -8,6 +8,6 @@ defineProps<{
 
 <template>
   <LandingFeatures :headline="headline" :title="title" :description="description">
-    <ContentSlot />
+    <MDCSlot :use="$slots.default" />
   </LandingFeatures>
 </template>


### PR DESCRIPTION
## Summary

- Replace all 7 occurrences of `<ContentSlot />` with `<MDCSlot :use="$slots.default" />` in MDC wrapper components
- `ContentSlot` doesn't exist in Nuxt Content v3 — the correct component is `MDCSlot` from `@nuxtjs/mdc`

Closes #9

## Test plan

- [ ] Run `pnpm dev` and verify no `Failed to resolve component: ContentSlot` warnings in console
- [ ] Verify landing page renders all MDC sections correctly (features, steps, use cases, references)
- [ ] Run `pnpm generate` — all routes build without errors