### PR TITLE
fix: hydration mismatch in LandingFeature and LandingStep

### DIFF
--- a/components/content/LandingFeature.vue
+++ b/components/content/LandingFeature.vue
@@ -13,8 +13,8 @@ defineProps<{
     <h3 class="text-base font-semibold">
       {{ title }}
     </h3>
-    <p class="mt-2 text-sm text-muted">
+    <div class="mt-2 text-sm text-muted">
       <MDCSlot :use="$slots.default" />
-    </p>
+    </div>
   </div>
 </template>

--- a/components/content/LandingStep.vue
+++ b/components/content/LandingStep.vue
@@ -15,8 +15,8 @@ defineProps<{
     <h3 class="text-lg font-semibold">
       {{ title }}
     </h3>
-    <p class="mt-2 text-sm text-muted">
+    <div class="mt-2 text-sm text-muted">
       <MDCSlot :use="$slots.default" />
-    </p>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

- Replace `<p>` with `<div>` around `<MDCSlot>` in LandingFeature and LandingStep
- MDCSlot renders markdown containing `<p>` tags — nesting `<p>` inside `<p>` is invalid HTML, causing the browser to auto-close the outer `<p>` during SSR and producing a hydration mismatch

Closes #11

## Test plan

- [ ] Run `pnpm dev` and verify no hydration mismatch warnings in console
- [ ] Verify feature cards and step cards render content correctly
- [ ] Run `pnpm generate` — all routes build without errors