### PR TITLE
fix: reorder modules so Nuxt UI registers content components

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,9 +1,9 @@
 export default defineNuxtConfig({
   modules: [
+    '@nuxt/content',
     '@nuxt/ui',
     '@nuxtjs/i18n',
     '@nuxtjs/seo',
-    '@nuxt/content',
     '@nuxt/image',
   ],
 


### PR DESCRIPTION
## Summary

- Move `@nuxt/content` before `@nuxt/ui` in `nuxt.config.ts` modules array
- Nuxt UI checks `hasNuxtModule('@nuxt/content')` during setup to register `ContentNavigation` and `ContentToc` — when `@nuxt/content` was listed after `@nuxt/ui`, the check returned false

Closes #13

## Test plan

- [ ] Run `pnpm dev` and navigate to `/fr/docs` — no `Failed to resolve component` warnings
- [ ] Verify sidebar navigation and table of contents render correctly
- [ ] Run `pnpm generate` — all routes build without errors