### PR TITLE
fix: replace "portail qualité" with "filtre qualité"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Clearance Website — marketing/presentational site for Clearance, an open-source quality gate for OpenStreetMap data.
+Clearance Website — marketing/presentational site for Clearance, an open-source quality filter for OpenStreetMap data.
 
 ## Tech Stack
 

--- a/content/en/contact.md
+++ b/content/en/contact.md
@@ -1,4 +1,4 @@
 ---
 title: "Contact - Clearance"
-description: "Contact the Clearance team for a demo, support, or any question about the OpenStreetMap quality gate."
+description: "Contact the Clearance team for a demo, support, or any question about the OpenStreetMap quality filter."
 ---

--- a/content/en/docs/1.getting-started/1.overview.md
+++ b/content/en/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: What is Clearance and why it exists — open source quality gate for OpenStreetMap.
+description: What is Clearance and why it exists — open source quality filter for OpenStreetMap.
 icon: i-lucide-info
 ---
 
@@ -8,7 +8,7 @@ icon: i-lucide-info
 
 ## What is Clearance?
 
-Clearance is an **open source quality gate** for OpenStreetMap data. It sits between the global OpenStreetMap database and your applications to filter and validate changes before they reach your systems.
+Clearance is an **open source quality filter** for OpenStreetMap data. It sits between the global OpenStreetMap database and your applications to filter and validate changes before they reach your systems.
 
 ## Reusing OpenStreetMap data with confidence
 

--- a/content/en/docs/index.md
+++ b/content/en/docs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Documentation
-description: Complete documentation for Clearance, the open source quality gate for OpenStreetMap data.
+description: Complete documentation for Clearance, the open source quality filter for OpenStreetMap data.
 navigation: false
 ---

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -1,11 +1,11 @@
 ---
-title: "Clearance - Quality Gate for OpenStreetMap Data"
+title: "Clearance - Quality Filter for OpenStreetMap Data"
 description: "Take control of the quality of the OpenStreetMap data you use or redistribute. Clearance automatically passes compliant changes and holds suspicious ones for review."
 ---
 
 ::landing-hero
 ---
-headline: Open source quality gate
+headline: Open source quality filter
 title: Take control of your OpenStreetMap data quality
 description: "Using OpenStreetMap in a critical context? An error can block an emergency route, distort a calculation, or engage your liability. Clearance helps you prevent that."
 primaryLabel: View on GitHub
@@ -25,7 +25,7 @@ description: "A complete quality assurance pipeline between OpenStreetMap and yo
   ::landing-feature
   ---
   icon: i-lucide-shield-check
-  title: Quality gate
+  title: Quality filter
   ---
   Automatically integrates compliant changes while holding suspicious modifications for human review.
   ::

--- a/content/es/contact.md
+++ b/content/es/contact.md
@@ -1,4 +1,4 @@
 ---
 title: "Contacto - Clearance"
-description: "Contacte al equipo de Clearance para una demo, asistencia o cualquier pregunta sobre el portal de calidad OpenStreetMap."
+description: "Contacte al equipo de Clearance para una demo, asistencia o cualquier pregunta sobre el filtro de calidad OpenStreetMap."
 ---

--- a/content/es/docs/1.getting-started/1.overview.md
+++ b/content/es/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Descripción general
-description: Qué es Clearance y por qué existe — portal de calidad open source para OpenStreetMap.
+description: Qué es Clearance y por qué existe — filtro de calidad open source para OpenStreetMap.
 icon: i-lucide-info
 ---
 
@@ -8,7 +8,7 @@ icon: i-lucide-info
 
 ## ¿Qué es Clearance?
 
-Clearance es un **portal de calidad open source** para datos de OpenStreetMap. Se interpone entre la base de datos mundial de OpenStreetMap y sus aplicaciones para filtrar y validar los cambios antes de que lleguen a sus sistemas.
+Clearance es un **filtro de calidad open source** para datos de OpenStreetMap. Se interpone entre la base de datos mundial de OpenStreetMap y sus aplicaciones para filtrar y validar los cambios antes de que lleguen a sus sistemas.
 
 ## Reutilizar los datos de OpenStreetMap con confianza
 

--- a/content/es/docs/index.md
+++ b/content/es/docs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Documentación
-description: Documentación completa de Clearance, el portal de calidad open source para datos de OpenStreetMap.
+description: Documentación completa de Clearance, el filtro de calidad open source para datos de OpenStreetMap.
 navigation: false
 ---

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -1,11 +1,11 @@
 ---
-title: "Clearance - Portal de calidad para datos de OpenStreetMap"
+title: "Clearance - Filtro de calidad para datos de OpenStreetMap"
 description: "Controle la calidad de los datos de OpenStreetMap que utiliza o redistribuye. Clearance filtra automáticamente los cambios conformes y retiene los sospechosos para verificación."
 ---
 
 ::landing-hero
 ---
-headline: Portal de calidad open source
+headline: Filtro de calidad open source
 title: Controle la calidad de sus datos OpenStreetMap
 description: "¿Utiliza OpenStreetMap en un contexto crítico? Un error puede bloquear una ruta de emergencia, falsear un cálculo o comprometer su responsabilidad. Clearance le ayuda a prevenirlo."
 primaryLabel: Ver en GitHub
@@ -25,7 +25,7 @@ description: "Un pipeline completo de aseguramiento de calidad entre OpenStreetM
   ::landing-feature
   ---
   icon: i-lucide-shield-check
-  title: Portal de calidad
+  title: Filtro de calidad
   ---
   Integra automáticamente los cambios conformes mientras retiene las modificaciones sospechosas para revisión humana.
   ::

--- a/content/fr/contact.md
+++ b/content/fr/contact.md
@@ -1,4 +1,4 @@
 ---
 title: "Contact - Clearance"
-description: "Contactez l'équipe Clearance pour une démo, un accompagnement ou toute question sur le portail qualité OpenStreetMap."
+description: "Contactez l'équipe Clearance pour une démo, un accompagnement ou toute question sur le filtre qualité OpenStreetMap."
 ---

--- a/content/fr/docs/1.getting-started/1.overview.md
+++ b/content/fr/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Vue d'ensemble
-description: Qu'est-ce que Clearance et pourquoi il existe — portail qualité open source pour OpenStreetMap.
+description: Qu'est-ce que Clearance et pourquoi il existe — filtre qualité open source pour OpenStreetMap.
 icon: i-lucide-info
 ---
 
@@ -8,7 +8,7 @@ icon: i-lucide-info
 
 ## Qu'est-ce que Clearance ?
 
-Clearance est un **portail qualité open source** pour les données OpenStreetMap. Il s'intercale entre la base de données mondiale OpenStreetMap et vos applications pour filtrer et valider les modifications avant qu'elles n'atteignent vos systèmes.
+Clearance est un **filtre qualité open source** pour les données OpenStreetMap. Il s'intercale entre la base de données mondiale OpenStreetMap et vos applications pour filtrer et valider les modifications avant qu'elles n'atteignent vos systèmes.
 
 ## Réutiliser les données OpenStreetMap avec confiance
 

--- a/content/fr/docs/index.md
+++ b/content/fr/docs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Documentation
-description: Documentation complète de Clearance, le portail qualité open source pour les données OpenStreetMap.
+description: Documentation complète de Clearance, le filtre qualité open source pour les données OpenStreetMap.
 navigation: false
 ---

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -1,11 +1,11 @@
 ---
-title: "Clearance - Portail qualité pour les données OpenStreetMap"
+title: "Clearance - Filtre qualité pour les données OpenStreetMap"
 description: "Maîtrisez la qualité des données OpenStreetMap que vous utilisez ou rediffusez. Clearance filtre automatiquement les modifications conformes et retient les changements suspects pour vérification."
 ---
 
 ::landing-hero
 ---
-headline: Portail qualité open source
+headline: Filtre qualité open source
 title: Maîtrisez la qualité de vos données OpenStreetMap
 description: "Vous utilisez OpenStreetMap dans un contexte critique ? Une erreur peut bloquer un itinéraire de secours, fausser un calcul ou engager votre responsabilité. Clearance vous aide à vous en prémunir."
 primaryLabel: Voir sur GitHub
@@ -25,7 +25,7 @@ description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vo
   ::landing-feature
   ---
   icon: i-lucide-shield-check
-  title: Portail qualité
+  title: Filtre qualité
   ---
   Intègre automatiquement les modifications conformes tout en retenant les changements suspects pour vérification humaine.
   ::

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   site: {
     url: 'https://clearance.teritorio.xyz',
     name: 'Clearance',
-    description: 'Open source quality gate for OpenStreetMap data — filter, validate, and secure your OSM data pipeline.',
+    description: 'Open source quality filter for OpenStreetMap data — filter, validate, and secure your OSM data pipeline.',
     defaultLocale: 'fr',
   },
 


### PR DESCRIPTION
## Summary

- Replaced incorrect "portail qualité" / "quality gate" / "portal de calidad" terminology with "filtre qualité" / "quality filter" / "filtro de calidad" across all user-facing content
- The reference content uses "filtre qualité" and "proxy qualité", not "portail qualité"
- 13 files updated across FR/EN/ES: homepage, overview docs, docs index, contact pages, and site config

## Test plan

- [x] `pnpm generate` passes with 0 errors
- [ ] Verify terminology is consistent across all pages in all 3 languages

Closes #21