### PR TITLE
fix: docs sidebar navigation not reactive on locale switch

### DIFF
--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -11,7 +11,7 @@ useHead({
 const collectionName = computed(() => `content_${locale.value}` as const)
 
 const { data: navigation } = await useAsyncData(
-  'docs-navigation',
+  `docs-navigation-${locale.value}`,
   () => queryCollectionNavigation(collectionName.value),
   { watch: [locale] },
 )

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -4,13 +4,14 @@ const route = useRoute()
 
 const collectionName = computed(() => `content_${locale.value}` as const)
 
+const slug = computed(() => (route.params.slug as string[]) || [])
+
 const path = computed(() => {
-  const slug = (route.params.slug as string[]) || []
-  return `/${locale.value}/${slug.join('/')}`
+  return `/${locale.value}/${slug.value.join('/')}`
 })
 
 const { data: page } = await useAsyncData(
-  `slug-${route.path}`,
+  `slug-${locale.value}-${slug.value.join('/')}`,
   () => queryCollection(collectionName.value).path(path.value).first(),
   { watch: [locale] },
 )


### PR DESCRIPTION
## Summary

- Add `{ watch: [locale] }` to `useAsyncData` in `pages/[...slug].vue` so sidebar navigation and page content update when switching locale

This aligns with the pattern already used in `pages/index.vue`, `pages/contact.vue`, and `layouts/docs.vue`.

Closes #39