### PR TITLE
fix: remove duplicate section index pages from docs sidebar

### DIFF
--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -39,7 +39,10 @@ const docsNavigation = computed(() => {
   }
 
   const docsSection = findDocsNode(navigation.value)
-  return docsSection?.children || []
+  return (docsSection?.children || []).map(section => ({
+    ...section,
+    children: section.children?.filter(child => child.path !== section.path),
+  }))
 })
 </script>
 


### PR DESCRIPTION
## Summary
- Filter each docs section's children to exclude items whose `path` matches the parent section's `path`, preventing `index.md` from appearing as both the section header and a redundant first child.

## Test plan
- [ ] `pnpm dev` — navigate to `/en/docs/getting-started/overview`
- [ ] Confirm sidebar shows section headers without duplicate first children
- [ ] Confirm all leaf pages (Overview, How it works, etc.) still appear
- [ ] Switch locale (FR/ES) — confirm same behavior

Closes #41