### PR TITLE
fix(seo): add descriptive alt text to header logo

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -48,7 +48,7 @@ const localeItems = computed(() =>
   <UHeader :to="localePath('/')">
     <template #title>
       <div class="flex items-center gap-2">
-        <img src="/logo.svg" alt="" width="28" height="28">
+        <img src="/logo.svg" alt="Clearance" width="28" height="28">
         <span>{{ t('nav.home') }}</span>
       </div>
     </template>


### PR DESCRIPTION
## Summary
- Replace empty `alt=""` with `alt="Clearance"` on the header logo image for better accessibility and SEO.

## Test plan
- [ ] Inspect the logo `<img>` in DevTools — confirm `alt="Clearance"`
- [ ] Run Lighthouse accessibility audit — confirm no missing alt text warnings

Closes #28