### PR TITLE
fix(seo): complete prerender routes for full sitemap coverage

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,9 +46,14 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       routes: ['fr', 'en', 'es'].flatMap(locale => [
+        `/${locale}`,
+        `/${locale}/contact`,
+        `/${locale}/docs`,
+        `/${locale}/docs/getting-started`,
         `/${locale}/docs/getting-started/overview`,
         `/${locale}/docs/getting-started/how-it-works`,
         `/${locale}/docs/getting-started/rules`,
+        `/${locale}/docs/going-further`,
         `/${locale}/docs/going-further/integration`,
         `/${locale}/docs/going-further/deployment`,
         `/${locale}/docs/going-further/references`,


### PR DESCRIPTION
## Summary
- Add missing prerender routes: locale homepages (`/fr`, `/en`, `/es`), contact pages, and docs section index pages
- Ensures all pages are statically generated and included in the sitemap

## Test plan
- [ ] `pnpm generate` — verify all routes are generated without errors
- [ ] Check `.output/public/` for the new pages
- [ ] Verify sitemap includes all routes

Closes #31