### PR TITLE
feat(seo): optimize doc titles, descriptions, and cross-links

### DIFF
--- a/content/en/docs/1.getting-started/1.overview.md
+++ b/content/en/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: What is Clearance and why it exists — open source quality filter for OpenStreetMap.
+title: Clearance Overview
+description: "Discover Clearance, the open source quality filter for OpenStreetMap data. Learn why controlling OSM data quality matters and how Clearance fits into your replication pipeline."
 icon: i-lucide-info
 ---
 
@@ -46,3 +46,9 @@ You get an up-to-date version of OpenStreetMap data, reliable for your use cases
 ## License
 
 Clearance is free software distributed under the **AGPL-3.0 license**. It is developed and maintained by [Teritorio](https://teritorio.fr).
+
+## See also
+
+- [How Clearance works](/en/docs/getting-started/how-it-works) — LoCha, semantic analysis, and validation flow
+- [Validation rules](/en/docs/getting-started/rules) — The seven rule categories
+- [Integration](/en/docs/going-further/integration) — Connecting Clearance to your infrastructure

--- a/content/en/docs/1.getting-started/2.how-it-works.md
+++ b/content/en/docs/1.getting-started/2.how-it-works.md
@@ -1,6 +1,6 @@
 ---
-title: How it works
-description: How Clearance filters and validates OpenStreetMap changes — LoCha, semantic analysis, validation flow.
+title: How Clearance Works
+description: "Learn how Clearance filters and validates OpenStreetMap changes in real time using Logical Changesets (LoCha), semantic analysis, and configurable validation rules."
 icon: i-lucide-cog
 ---
 
@@ -57,3 +57,9 @@ The operator accesses the Clearance web interface to examine held changes. For e
 ### 5. Output
 
 Validated changes (automatically or manually) are made available as [standard outputs](/en/docs/going-further/integration).
+
+## See also
+
+- [Clearance Overview](/en/docs/getting-started/overview) — What Clearance is and why it exists
+- [Validation rules](/en/docs/getting-started/rules) — Detailed reference for all seven rule categories
+- [Deployment options](/en/docs/going-further/deployment) — SaaS or self-hosted

--- a/content/en/docs/1.getting-started/3.rules.md
+++ b/content/en/docs/1.getting-started/3.rules.md
@@ -1,6 +1,6 @@
 ---
-title: Validation rules
-description: Complete reference of Clearance validation rules — delayed, deleted, duplicate, geom, network, tags, user_list.
+title: Validation Rules
+description: "Complete reference of Clearance's seven validation rule categories: delayed changes, deleted objects, duplicates, geometry checks, network consistency, tag verification, and user lists."
 icon: i-lucide-list-checks
 ---
 
@@ -67,3 +67,9 @@ Allows defining lists of users whose changes require special attention. Can be u
 
 - **Whitelist** — Only listed users pass automatically
 - **Blacklist** — Changes from listed users are systematically held
+
+## See also
+
+- [How Clearance works](/en/docs/getting-started/how-it-works) — Understand the validation flow
+- [Integration](/en/docs/going-further/integration) — Connect Clearance to your infrastructure
+- [References](/en/docs/going-further/references) — See how organizations use these rules in production

--- a/content/en/docs/2.going-further/1.integration.md
+++ b/content/en/docs/2.going-further/1.integration.md
@@ -1,6 +1,6 @@
 ---
-title: Integration
-description: Standard outputs, Overpass API proxy, and integrating Clearance into your infrastructure.
+title: Integration Guide
+description: "Learn how to integrate Clearance into your infrastructure using standard OSM diff files, the transparent Overpass API proxy, or direct database access for validated OpenStreetMap data."
 icon: i-lucide-plug
 ---
 
@@ -49,3 +49,9 @@ OpenStreetMap
 ## Configuration
 
 To configure integration with your infrastructure, see the [GitHub repository](https://github.com/teritorio/clearance) for detailed installation and configuration instructions.
+
+## See also
+
+- [Deployment options](/en/docs/going-further/deployment) — SaaS managed service or self-hosted
+- [How Clearance works](/en/docs/getting-started/how-it-works) — Understand the validation pipeline
+- [Validation rules](/en/docs/getting-started/rules) — Configure rules for your quality needs

--- a/content/en/docs/2.going-further/2.deployment.md
+++ b/content/en/docs/2.going-further/2.deployment.md
@@ -1,6 +1,6 @@
 ---
-title: Deployment
-description: Clearance deployment options — managed SaaS vs self-hosted, business model and pricing.
+title: Deployment Options
+description: "Choose between Clearance SaaS managed hosting by Teritorio or self-hosted deployment on your own infrastructure. Compare benefits, prerequisites, and pricing for each option."
 icon: i-lucide-server
 ---
 
@@ -59,3 +59,9 @@ For each project, the following items should be considered:
 To get a quote or discuss your needs, [contact us](/en/contact).
 
 For self-hosted deployment, see the instructions on the [GitHub repository](https://github.com/teritorio/clearance).
+
+## See also
+
+- [Integration guide](/en/docs/going-further/integration) — Connect Clearance to your tools
+- [References](/en/docs/going-further/references) — Organizations using Clearance in production
+- [Contact us](/en/contact) — Request a quote or demo

--- a/content/en/docs/2.going-further/3.references.md
+++ b/content/en/docs/2.going-further/3.references.md
@@ -1,6 +1,6 @@
 ---
-title: References
-description: Clearance use cases and clients — local authorities, transport operators, tourism offices.
+title: Client References
+description: "Over 40 organizations trust Clearance for OpenStreetMap quality control, including SNCF Réseau, Civil Protection of Navarre, and 30 French tourism offices and departmental agencies."
 icon: i-lucide-building
 ---
 
@@ -37,3 +37,9 @@ The **NLNet** foundation also funds part of the development through European fun
 ## Become a reference
 
 Do you use Clearance and want to be listed as a reference? [Contact us](/en/contact).
+
+## See also
+
+- [Clearance Overview](/en/docs/getting-started/overview) — What Clearance is and how it works
+- [Deployment options](/en/docs/going-further/deployment) — Get started with SaaS or self-hosted
+- [Roadmap](/en/docs/going-further/roadmap) — Upcoming features and development plans

--- a/content/en/docs/2.going-further/4.roadmap.md
+++ b/content/en/docs/2.going-further/4.roadmap.md
@@ -1,6 +1,6 @@
 ---
-title: Roadmap
-description: Future developments for Clearance — NLNet funding, external sources, reputation system.
+title: Development Roadmap
+description: "Explore Clearance's development roadmap: NLNet-funded improvements, external data source integration, contributor reputation system, and enhanced dashboard and visualization features."
 icon: i-lucide-map-pin
 ---
 
@@ -41,3 +41,9 @@ Clearance is open source. Contributions are welcome on the [GitHub repository](h
 - Report bugs or suggest improvements via issues
 - Submit a pull request
 - Join the discussions
+
+## See also
+
+- [Clearance Overview](/en/docs/getting-started/overview) — What Clearance is and why it exists
+- [References](/en/docs/going-further/references) — Organizations using Clearance today
+- [Contact us](/en/contact) — Discuss your needs or suggest features

--- a/content/es/docs/1.getting-started/1.overview.md
+++ b/content/es/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
-title: Descripción general
-description: Qué es Clearance y por qué existe — filtro de calidad open source para OpenStreetMap.
+title: Descripción general de Clearance
+description: "Descubra Clearance, el filtro de calidad open source para datos de OpenStreetMap. Aprenda por qué el control de calidad de datos OSM es esencial y cómo Clearance se integra en su pipeline."
 icon: i-lucide-info
 ---
 
@@ -46,3 +46,9 @@ Así obtiene una versión actualizada de los datos OpenStreetMap, fiable para su
 ## Licencia
 
 Clearance es software libre distribuido bajo la licencia **AGPL-3.0**. Es desarrollado y mantenido por [Teritorio](https://teritorio.fr).
+
+## Ver también
+
+- [Cómo funciona Clearance](/es/docs/getting-started/how-it-works) — Descubra el funcionamiento técnico de Clearance: LoCha, análisis semántico y flujo de validación
+- [Reglas de validación](/es/docs/getting-started/rules) — Referencia completa de las siete categorías de reglas de validación disponibles
+- [Guía de integración](/es/docs/going-further/integration) — Aprenda a integrar Clearance en su infraestructura existente

--- a/content/es/docs/1.getting-started/2.how-it-works.md
+++ b/content/es/docs/1.getting-started/2.how-it-works.md
@@ -1,6 +1,6 @@
 ---
-title: Funcionamiento
-description: Cómo Clearance filtra y valida los cambios de OpenStreetMap — LoCha, análisis semántico, flujo de validación.
+title: Cómo funciona Clearance
+description: "Descubra cómo Clearance filtra y valida los cambios de OpenStreetMap en tiempo real mediante Changesets Lógicos (LoCha), análisis semántico y reglas de validación configurables."
 icon: i-lucide-cog
 ---
 
@@ -57,3 +57,9 @@ El operador accede a la interfaz web de Clearance para examinar los cambios rete
 ### 5. Salida
 
 Los cambios validados (automática o manualmente) se ponen a disposición como [salidas estándar](/es/docs/going-further/integration).
+
+## Ver también
+
+- [Descripción general de Clearance](/es/docs/getting-started/overview) — Qué es Clearance y por qué el control de calidad de datos OSM es esencial
+- [Reglas de validación](/es/docs/getting-started/rules) — Referencia completa de las siete categorías de reglas de validación disponibles
+- [Opciones de despliegue](/es/docs/going-further/deployment) — Compare las opciones SaaS gestionado y autoalojado para desplegar Clearance

--- a/content/es/docs/1.getting-started/3.rules.md
+++ b/content/es/docs/1.getting-started/3.rules.md
@@ -1,6 +1,6 @@
 ---
 title: Reglas de validación
-description: Referencia completa de las reglas de validación de Clearance — delayed, deleted, duplicate, geom, network, tags, user_list.
+description: "Referencia completa de las siete categorías de reglas de validación de Clearance: cambios retrasados, objetos eliminados, duplicados, verificaciones geométricas, coherencia de red, tags y listas de usuarios."
 icon: i-lucide-list-checks
 ---
 
@@ -67,3 +67,9 @@ Permite definir listas de usuarios cuyas modificaciones requieren atención espe
 
 - **Lista blanca** — Solo los usuarios listados pasan automáticamente
 - **Lista negra** — Los cambios de los usuarios listados se retienen sistemáticamente
+
+## Ver también
+
+- [Cómo funciona Clearance](/es/docs/getting-started/how-it-works) — Comprenda el flujo de validación que aplica estas reglas
+- [Guía de integración](/es/docs/going-further/integration) — Integre los datos validados por Clearance en su infraestructura
+- [Referencias de clientes](/es/docs/going-further/references) — Descubra cómo más de 40 organizaciones usan Clearance

--- a/content/es/docs/2.going-further/1.integration.md
+++ b/content/es/docs/2.going-further/1.integration.md
@@ -1,6 +1,6 @@
 ---
-title: Integración
-description: Salidas estándar, proxy Overpass API e integración de Clearance en su infraestructura.
+title: Guía de integración
+description: "Aprenda a integrar Clearance en su infraestructura mediante archivos diff OSM estándar, el proxy transparente Overpass API o el acceso directo a la base de datos validada de OpenStreetMap."
 icon: i-lucide-plug
 ---
 
@@ -49,3 +49,9 @@ OpenStreetMap
 ## Configuración
 
 Para configurar la integración con su infraestructura, consulte el [repositorio GitHub](https://github.com/teritorio/clearance) para las instrucciones detalladas de instalación y configuración.
+
+## Ver también
+
+- [Opciones de despliegue](/es/docs/going-further/deployment) — Compare las opciones SaaS gestionado y autoalojado para desplegar Clearance
+- [Cómo funciona Clearance](/es/docs/getting-started/how-it-works) — Comprenda el flujo de validación que alimenta estas salidas
+- [Reglas de validación](/es/docs/getting-started/rules) — Configure las reglas que determinan qué cambios se validan automáticamente

--- a/content/es/docs/2.going-further/2.deployment.md
+++ b/content/es/docs/2.going-further/2.deployment.md
@@ -1,6 +1,6 @@
 ---
-title: Despliegue
-description: Opciones de despliegue de Clearance — SaaS gestionado vs autoalojado, modelo de negocio y precios.
+title: Opciones de despliegue
+description: "Elija entre el alojamiento SaaS gestionado por Teritorio o el despliegue autoalojado. Compare ventajas, requisitos previos y precios de cada opción de despliegue de Clearance."
 icon: i-lucide-server
 ---
 
@@ -59,3 +59,9 @@ Para cada proyecto, se deben considerar los siguientes elementos:
 Para obtener un presupuesto o discutir sus necesidades, [contáctenos](/es/contact).
 
 Para un despliegue autónomo, consulte las instrucciones en el [repositorio GitHub](https://github.com/teritorio/clearance).
+
+## Ver también
+
+- [Guía de integración](/es/docs/going-further/integration) — Aprenda a integrar Clearance en su infraestructura existente
+- [Referencias de clientes](/es/docs/going-further/references) — Descubra cómo más de 40 organizaciones usan Clearance
+- [Contacto](/es/contact) — Solicite un presupuesto o discuta sus necesidades con nuestro equipo

--- a/content/es/docs/2.going-further/3.references.md
+++ b/content/es/docs/2.going-further/3.references.md
@@ -1,6 +1,6 @@
 ---
-title: Referencias
-description: Casos de uso y clientes de Clearance — administraciones locales, operadores de transporte, oficinas de turismo.
+title: Referencias de clientes
+description: "Más de 40 organizaciones confían en Clearance para el control de calidad OpenStreetMap, incluyendo SNCF Réseau, Protección Civil de Navarra y 30 oficinas de turismo y agencias departamentales francesas."
 icon: i-lucide-building
 ---
 
@@ -37,3 +37,9 @@ La fundación **NLNet** también financia parte de los desarrollos mediante fond
 ## Convertirse en referencia
 
 ¿Utiliza Clearance y desea aparecer como referencia? [Contáctenos](/es/contact).
+
+## Ver también
+
+- [Descripción general de Clearance](/es/docs/getting-started/overview) — Qué es Clearance y por qué el control de calidad de datos OSM es esencial
+- [Opciones de despliegue](/es/docs/going-further/deployment) — Compare las opciones SaaS gestionado y autoalojado para desplegar Clearance
+- [Hoja de ruta](/es/docs/going-further/roadmap) — Explore las próximas funcionalidades y mejoras planificadas

--- a/content/es/docs/2.going-further/4.roadmap.md
+++ b/content/es/docs/2.going-further/4.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Hoja de ruta
-description: Desarrollos futuros de Clearance — financiación NLNet, fuentes externas, sistema de reputación.
+description: "Explore la hoja de ruta de Clearance: mejoras financiadas por NLNet, integración de fuentes de datos externas, sistema de reputación de contribuidores y panel de control mejorado."
 icon: i-lucide-map-pin
 ---
 
@@ -41,3 +41,9 @@ Clearance es open source. Las contribuciones son bienvenidas en el [repositorio 
 - Reportar un error o proponer una mejora a través de issues
 - Enviar un pull request
 - Participar en las discusiones
+
+## Ver también
+
+- [Descripción general de Clearance](/es/docs/getting-started/overview) — Qué es Clearance y por qué el control de calidad de datos OSM es esencial
+- [Referencias de clientes](/es/docs/going-further/references) — Descubra cómo más de 40 organizaciones ya usan Clearance
+- [Contacto](/es/contact) — Solicite información o discuta sus necesidades con nuestro equipo

--- a/content/fr/docs/1.getting-started/1.overview.md
+++ b/content/fr/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
-title: Vue d'ensemble
-description: Qu'est-ce que Clearance et pourquoi il existe — filtre qualité open source pour OpenStreetMap.
+title: "Vue d'ensemble de Clearance"
+description: "Découvrez Clearance, le filtre qualité open source pour les données OpenStreetMap. Apprenez pourquoi le contrôle qualité des données OSM est essentiel et comment Clearance s'intègre à votre pipeline."
 icon: i-lucide-info
 ---
 
@@ -46,3 +46,9 @@ Vous disposez ainsi d'une version à jour des données OpenStreetMap, fiable pou
 ## Licence
 
 Clearance est un logiciel libre sous licence **AGPL-3.0**. Il est développé et maintenu par [Teritorio](https://teritorio.fr).
+
+## Voir aussi
+
+- [Fonctionnement de Clearance](/fr/docs/getting-started/how-it-works) — Comprendre le mécanisme de filtrage, les LoCha et le flux de validation
+- [Règles de validation](/fr/docs/getting-started/rules) — Découvrir les sept catégories de règles configurables
+- [Guide d'intégration](/fr/docs/going-further/integration) — Intégrer Clearance dans votre infrastructure existante

--- a/content/fr/docs/1.getting-started/2.how-it-works.md
+++ b/content/fr/docs/1.getting-started/2.how-it-works.md
@@ -1,6 +1,6 @@
 ---
-title: Fonctionnement
-description: Comment Clearance filtre et valide les modifications OpenStreetMap — LoCha, analyse sémantique, flux de validation.
+title: "Fonctionnement de Clearance"
+description: "Découvrez comment Clearance filtre et valide les modifications OpenStreetMap en temps réel grâce aux Changesets Logiques (LoCha), à l'analyse sémantique et aux règles de validation configurables."
 icon: i-lucide-cog
 ---
 
@@ -57,3 +57,9 @@ L'opérateur accède à l'interface web de Clearance pour examiner les modificat
 ### 5. Sortie
 
 Les modifications validées (automatiquement ou manuellement) sont mises à disposition sous forme de [sorties standards](/fr/docs/going-further/integration).
+
+## Voir aussi
+
+- [Vue d'ensemble de Clearance](/fr/docs/getting-started/overview) — Découvrir ce qu'est Clearance et pourquoi il existe
+- [Règles de validation](/fr/docs/getting-started/rules) — Référence complète des sept catégories de règles
+- [Options de déploiement](/fr/docs/going-further/deployment) — Choisir entre SaaS managé et auto-hébergé

--- a/content/fr/docs/1.getting-started/3.rules.md
+++ b/content/fr/docs/1.getting-started/3.rules.md
@@ -1,6 +1,6 @@
 ---
-title: Règles de validation
-description: Référence complète des règles de validation Clearance — delayed, deleted, duplicate, geom, network, tags, user_list.
+title: "Règles de validation"
+description: "Référence complète des sept catégories de règles de validation Clearance : modifications retardées, objets supprimés, doublons, vérifications géométriques, cohérence réseau, tags et listes d'utilisateurs."
 icon: i-lucide-list-checks
 ---
 
@@ -67,3 +67,9 @@ Permet de définir des listes d'utilisateurs dont les modifications nécessitent
 
 - **Liste blanche** — Seuls les utilisateurs listés passent automatiquement
 - **Liste noire** — Les modifications des utilisateurs listés sont systématiquement retenues
+
+## Voir aussi
+
+- [Fonctionnement de Clearance](/fr/docs/getting-started/how-it-works) — Comprendre comment les règles s'intègrent dans le flux de validation
+- [Guide d'intégration](/fr/docs/going-further/integration) — Intégrer les données filtrées dans votre infrastructure
+- [Références clients](/fr/docs/going-further/references) — Découvrir comment les organisations utilisent ces règles

--- a/content/fr/docs/2.going-further/1.integration.md
+++ b/content/fr/docs/2.going-further/1.integration.md
@@ -1,6 +1,6 @@
 ---
-title: Intégration
-description: Sorties standards, proxy Overpass API et intégration de Clearance dans votre infrastructure.
+title: "Guide d'intégration"
+description: "Apprenez à intégrer Clearance dans votre infrastructure via les fichiers diff OSM standards, le proxy transparent Overpass API ou l'accès direct à la base de données validée OpenStreetMap."
 icon: i-lucide-plug
 ---
 
@@ -49,3 +49,9 @@ OpenStreetMap
 ## Configuration
 
 Pour configurer l'intégration avec votre infrastructure, consultez le [dépôt GitHub](https://github.com/teritorio/clearance) pour les instructions détaillées d'installation et de configuration.
+
+## Voir aussi
+
+- [Options de déploiement](/fr/docs/going-further/deployment) — Choisir entre SaaS managé et auto-hébergé
+- [Fonctionnement de Clearance](/fr/docs/getting-started/how-it-works) — Comprendre le flux de validation en amont de l'intégration
+- [Règles de validation](/fr/docs/getting-started/rules) — Configurer les règles qui alimentent les sorties

--- a/content/fr/docs/2.going-further/2.deployment.md
+++ b/content/fr/docs/2.going-further/2.deployment.md
@@ -1,6 +1,6 @@
 ---
-title: Déploiement
-description: Options de déploiement Clearance — SaaS managé vs auto-hébergé, modèle économique et tarification.
+title: "Options de déploiement"
+description: "Choisissez entre l'hébergement SaaS managé par Teritorio ou le déploiement auto-hébergé. Comparez les avantages, prérequis et tarification de chaque option de déploiement Clearance."
 icon: i-lucide-server
 ---
 
@@ -59,3 +59,9 @@ Pour chaque projet, les postes suivants sont à considérer :
 Pour obtenir un devis ou discuter de vos besoins, [contactez-nous](/fr/contact).
 
 Pour un déploiement autonome, consultez les instructions sur le [dépôt GitHub](https://github.com/teritorio/clearance).
+
+## Voir aussi
+
+- [Guide d'intégration](/fr/docs/going-further/integration) — Connecter Clearance à vos outils existants
+- [Références clients](/fr/docs/going-further/references) — Voir comment d'autres organisations déploient Clearance
+- [Contactez-nous](/fr/contact) — Obtenir un devis ou discuter de vos besoins

--- a/content/fr/docs/2.going-further/3.references.md
+++ b/content/fr/docs/2.going-further/3.references.md
@@ -1,6 +1,6 @@
 ---
-title: Références
-description: Cas d'usage et clients de Clearance — collectivités, opérateurs de transport, offices de tourisme.
+title: "Références clients"
+description: "Plus de 40 organisations font confiance à Clearance pour le contrôle qualité OpenStreetMap, dont SNCF Réseau, la Sécurité civile de Navarre et 30 offices de tourisme et agences départementales français."
 icon: i-lucide-building
 ---
 
@@ -37,3 +37,9 @@ La fondation **NLNet** finance également une partie des développements, via de
 ## Devenir référence
 
 Vous utilisez Clearance et souhaitez apparaître comme référence ? [Contactez-nous](/fr/contact).
+
+## Voir aussi
+
+- [Vue d'ensemble de Clearance](/fr/docs/getting-started/overview) — Comprendre ce qu'est Clearance et comment il fonctionne
+- [Options de déploiement](/fr/docs/going-further/deployment) — Choisir le modèle de déploiement adapté à votre organisation
+- [Feuille de route](/fr/docs/going-further/roadmap) — Découvrir les fonctionnalités à venir

--- a/content/fr/docs/2.going-further/4.roadmap.md
+++ b/content/fr/docs/2.going-further/4.roadmap.md
@@ -1,6 +1,6 @@
 ---
-title: Feuille de route
-description: Développements futurs de Clearance — NLNet, sources externes, système de réputation.
+title: "Feuille de route"
+description: "Découvrez la feuille de route de Clearance : améliorations financées par NLNet, intégration de sources de données externes, système de réputation des contributeurs et tableau de bord amélioré."
 icon: i-lucide-map-pin
 ---
 
@@ -41,3 +41,9 @@ Clearance est open source. Les contributions sont les bienvenues sur le [dépôt
 - Signaler un bug ou proposer une amélioration via les issues
 - Soumettre une pull request
 - Participer aux discussions
+
+## Voir aussi
+
+- [Vue d'ensemble de Clearance](/fr/docs/getting-started/overview) — Revenir aux fondamentaux de Clearance
+- [Références clients](/fr/docs/going-further/references) — Découvrir les organisations qui utilisent déjà Clearance
+- [Contactez-nous](/fr/contact) — Proposer des fonctionnalités ou discuter de vos besoins


### PR DESCRIPTION
## Summary
- Add keywords to documentation page titles for better search engine ranking (e.g., "Overview" → "Clearance Overview")
- Expand meta descriptions from ~80-110 chars to 120-160 chars across all locales (en/fr/es)
- Add "See also" / "Voir aussi" / "Ver también" cross-link sections at the bottom of every docs page

## Test plan
- [ ] `pnpm dev` — verify docs pages render correctly with new titles
- [ ] Check page source for updated `<title>` and `<meta name="description">` tags
- [ ] Verify sidebar navigation still works (titles should display correctly)
- [ ] Click through cross-links in each locale to confirm they resolve

Closes #26
Closes #32
Closes #36