### PR TITLE
feat(seo): add structured data, breadcrumbs, NuxtImg, and contact content

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -6,6 +6,23 @@ const uiLocales: Record<string, typeof en> = { en, fr, es }
 const { locale } = useI18n()
 const route = useRoute()
 const uiLocale = computed(() => uiLocales[locale.value] || en)
+
+useSchemaOrg([
+  defineOrganization({
+    name: 'Teritorio',
+    url: 'https://teritorio.fr',
+    logo: 'https://clearance.teritorio.xyz/logo.svg',
+  }),
+  defineSoftwareApp({
+    name: 'Clearance',
+    operatingSystem: 'Linux',
+    applicationCategory: 'DeveloperApplication',
+    offers: {
+      price: '0',
+      priceCurrency: 'EUR',
+    },
+  }),
+])
 </script>
 
 <template>

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -48,7 +48,7 @@ const localeItems = computed(() =>
   <UHeader :to="localePath('/')">
     <template #title>
       <div class="flex items-center gap-2">
-        <img src="/logo.svg" alt="Clearance" width="28" height="28">
+        <NuxtImg src="/logo.svg" alt="Clearance" width="28" height="28" />
         <span>{{ t('nav.home') }}</span>
       </div>
     </template>

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -30,6 +30,13 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'your{\'@\'}email.com',
     organizationPlaceholder: 'Your organization',
     messagePlaceholder: 'Describe your project or question...',
+    whyTitle: 'Why contact us?',
+    whyItem1: 'Get a personalized assessment of your OpenStreetMap data quality needs',
+    whyItem2: 'Discuss deployment options: managed SaaS or self-hosted',
+    whyItem3: 'Learn how Clearance integrates with your existing infrastructure',
+    whyItem4: 'Explore custom validation rules for your specific use case',
+    openSource: 'Clearance is open source (AGPL-3.0). You can explore the code and documentation on {link}.',
+    github: 'GitHub',
   },
   docs: {
     toc: 'On this page',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -30,6 +30,13 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'su{\'@\'}correo.com',
     organizationPlaceholder: 'Su organización',
     messagePlaceholder: 'Describa su proyecto o pregunta...',
+    whyTitle: '¿Por qué contactarnos?',
+    whyItem1: 'Obtenga una evaluación personalizada de sus necesidades de calidad de datos OpenStreetMap',
+    whyItem2: 'Discuta las opciones de despliegue: SaaS gestionado o autoalojado',
+    whyItem3: 'Descubra cómo Clearance se integra con su infraestructura existente',
+    whyItem4: 'Explore reglas de validación personalizadas para su caso de uso',
+    openSource: 'Clearance es open source (AGPL-3.0). Puede explorar el código y la documentación en {link}.',
+    github: 'GitHub',
   },
   docs: {
     toc: 'En esta página',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -30,6 +30,13 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'votre{\'@\'}email.com',
     organizationPlaceholder: 'Votre organisation',
     messagePlaceholder: 'Décrivez votre projet ou votre question...',
+    whyTitle: 'Pourquoi nous contacter ?',
+    whyItem1: 'Obtenez une évaluation personnalisée de vos besoins en qualité de données OpenStreetMap',
+    whyItem2: 'Discutez des options de déploiement : SaaS managé ou auto-hébergé',
+    whyItem3: 'Découvrez comment Clearance s\'intègre à votre infrastructure existante',
+    whyItem4: 'Explorez des règles de validation personnalisées pour votre cas d\'usage',
+    openSource: 'Clearance est open source (AGPL-3.0). Vous pouvez explorer le code et la documentation sur {link}.',
+    github: 'GitHub',
   },
   docs: {
     toc: 'Sur cette page',

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+const hyphenPattern = /-/g
+const firstCharPattern = /^\w/
+
 const { t, locale } = useI18n()
 const route = useRoute()
 
@@ -24,6 +27,28 @@ useHead({
     { name: 'description', content: () => page.value?.description },
   ],
 })
+
+useSchemaOrg([
+  defineBreadcrumb({
+    itemListElement: computed(() => {
+      const items: Array<{ name: string, item: string }> = [
+        { name: 'Clearance', item: `/${locale.value}` },
+      ]
+      if (isDocsPage.value) {
+        const parts = slug.value
+        if (parts.length >= 2)
+          items.push({ name: 'Docs', item: `/${locale.value}/docs` })
+        if (parts.length >= 3 && parts[1]) {
+          const section = parts[1]
+          items.push({ name: section.replace(hyphenPattern, ' ').replace(firstCharPattern, c => c.toUpperCase()), item: `/${locale.value}/docs/${section}` })
+        }
+        if (page.value?.title)
+          items.push({ name: page.value.title, item: `/${locale.value}/${parts.join('/')}` })
+      }
+      return items
+    }),
+  }),
+])
 
 definePageMeta({
   layout: false,

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -58,6 +58,25 @@ function onSubmit() {
         </ul>
       </div>
 
+      <div class="mt-8 rounded-lg border border-muted/20 bg-muted/5 p-6">
+        <h2 class="text-lg font-semibold">
+          {{ t('contact.whyTitle') }}
+        </h2>
+        <ul class="mt-3 space-y-1 text-sm text-muted list-disc list-inside">
+          <li>{{ t('contact.whyItem1') }}</li>
+          <li>{{ t('contact.whyItem2') }}</li>
+          <li>{{ t('contact.whyItem3') }}</li>
+          <li>{{ t('contact.whyItem4') }}</li>
+        </ul>
+        <p class="mt-3 text-sm text-muted">
+          <i18n-t keypath="contact.openSource" tag="span">
+            <template #link>
+              <a href="https://github.com/teritorio/clearance" target="_blank" class="text-primary underline">{{ t('contact.github') }}</a>
+            </template>
+          </i18n-t>
+        </p>
+      </div>
+
       <form class="mt-8 space-y-6" @submit.prevent="onSubmit">
         <UFormField :label="t('contact.name')">
           <UInput


### PR DESCRIPTION
## Summary
- Add Organization and SoftwareApplication JSON-LD schemas in `app.vue`
- Add BreadcrumbList structured data for docs pages in `[...slug].vue`
- Replace `<img>` with `<NuxtImg>` in AppHeader for optimized image loading
- Expand contact page with "Why contact us?" section across all 3 locales

## Test plan
- [ ] Check page source for JSON-LD structured data (Organization, SoftwareApplication)
- [ ] Navigate to a docs page and verify BreadcrumbList JSON-LD in source
- [ ] Verify header logo renders correctly with NuxtImg
- [ ] Check contact page shows new "Why contact us?" section in EN/FR/ES
- [ ] `pnpm lint:fix && pnpm typecheck` pass

Closes #27
Closes #29
Closes #30
Closes #35