### PR TITLE
fix(seo): use localized titles in BreadcrumbList structured data

### DIFF
--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-const hyphenPattern = /-/g
-const firstCharPattern = /^\w/
-
 const { t, locale } = useI18n()
 const route = useRoute()
 
@@ -21,6 +18,25 @@ const { data: page } = await useAsyncData(
 
 const isDocsPage = computed(() => path.value.includes('/docs'))
 
+const sectionSlug = computed(() => {
+  const parts = slug.value
+  return isDocsPage.value && parts.length >= 3 ? parts[1] : undefined
+})
+
+const { data: docsIndex } = await useAsyncData(
+  `breadcrumb-docs-${locale.value}`,
+  () => queryCollection(collectionName.value).path(`/${locale.value}/docs`).first(),
+  { watch: [locale] },
+)
+
+const { data: sectionIndex } = await useAsyncData(
+  `breadcrumb-section-${locale.value}-${sectionSlug.value}`,
+  () => sectionSlug.value
+    ? queryCollection(collectionName.value).path(`/${locale.value}/docs/${sectionSlug.value}`).first()
+    : Promise.resolve(null),
+  { watch: [locale] },
+)
+
 useHead({
   title: () => page.value?.title,
   meta: [
@@ -37,11 +53,9 @@ useSchemaOrg([
       if (isDocsPage.value) {
         const parts = slug.value
         if (parts.length >= 2)
-          items.push({ name: 'Docs', item: `/${locale.value}/docs` })
-        if (parts.length >= 3 && parts[1]) {
-          const section = parts[1]
-          items.push({ name: section.replace(hyphenPattern, ' ').replace(firstCharPattern, c => c.toUpperCase()), item: `/${locale.value}/docs/${section}` })
-        }
+          items.push({ name: docsIndex.value?.title || t('nav.docs'), item: `/${locale.value}/docs` })
+        if (parts.length >= 3 && sectionIndex.value?.title)
+          items.push({ name: sectionIndex.value.title, item: `/${locale.value}/docs/${parts[1]}` })
         if (page.value?.title)
           items.push({ name: page.value.title, item: `/${locale.value}/${parts.join('/')}` })
       }


### PR DESCRIPTION
## Summary
- Query docs index and section index pages from the content collection to get localized titles for BreadcrumbList JSON-LD
- Replaces hardcoded "Docs" with localized title (e.g., "Documentation" / "Documentación")
- Replaces slug-derived section names with actual localized titles (e.g., "Pour commencer" instead of "Getting started" in FR)

## Test plan
- [ ] Navigate to a docs page in FR — check page source for BreadcrumbList JSON-LD with French section names
- [ ] Same for ES — verify Spanish section names appear
- [ ] Verify EN still works correctly

Closes #48