### PR TITLE
fix(seo): localize og:image:alt and site description meta tags

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -3,9 +3,14 @@ import { en, es, fr } from '@nuxt/ui/locale'
 
 const uiLocales: Record<string, typeof en> = { en, fr, es }
 
-const { locale } = useI18n()
+const { t, locale } = useI18n()
 const route = useRoute()
 const uiLocale = computed(() => uiLocales[locale.value] || en)
+
+useSeoMeta({
+  description: () => t('seo.description'),
+  ogImageAlt: () => t('seo.ogImageAlt'),
+})
 
 useSchemaOrg([
   defineOrganization({

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -41,6 +41,10 @@ export default defineI18nLocale(async () => ({
   docs: {
     toc: 'On this page',
   },
+  seo: {
+    description: 'Open source quality filter for OpenStreetMap data — filter, validate, and secure your OSM data pipeline.',
+    ogImageAlt: 'Clearance — Quality filter for OpenStreetMap data',
+  },
   page: {
     empty: 'This page has no content yet.',
     notFound: 'Page not found',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -41,6 +41,10 @@ export default defineI18nLocale(async () => ({
   docs: {
     toc: 'En esta página',
   },
+  seo: {
+    description: 'Filtro de calidad open source para datos OpenStreetMap — filtre, valide y asegure su pipeline de datos OSM.',
+    ogImageAlt: 'Clearance — Filtro de calidad para datos OpenStreetMap',
+  },
   page: {
     empty: 'Esta página aún no tiene contenido.',
     notFound: 'Página no encontrada',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -41,6 +41,10 @@ export default defineI18nLocale(async () => ({
   docs: {
     toc: 'Sur cette page',
   },
+  seo: {
+    description: 'Filtre qualité open source pour les données OpenStreetMap — filtrez, validez et sécurisez votre pipeline de données OSM.',
+    ogImageAlt: 'Clearance — Filtre qualité pour les données OpenStreetMap',
+  },
   page: {
     empty: 'Cette page n\'a pas encore de contenu.',
     notFound: 'Page introuvable',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,6 @@ export default defineNuxtConfig({
         { property: 'og:image', content: 'https://clearance.teritorio.xyz/og-image.png' },
         { property: 'og:image:width', content: '1200' },
         { property: 'og:image:height', content: '630' },
-        { property: 'og:image:alt', content: 'Clearance — Quality filter for OpenStreetMap data' },
         { name: 'twitter:image', content: 'https://clearance.teritorio.xyz/og-image.png' },
       ],
     },
@@ -29,7 +28,6 @@ export default defineNuxtConfig({
   site: {
     url: 'https://clearance.teritorio.xyz',
     name: 'Clearance',
-    description: 'Open source quality filter for OpenStreetMap data — filter, validate, and secure your OSM data pipeline.',
     defaultLocale: 'fr',
   },
 


### PR DESCRIPTION
## Summary
- Remove hardcoded English `og:image:alt` and `site.description` from `nuxt.config.ts`
- Add `seo.description` and `seo.ogImageAlt` i18n keys in all 3 locales (en, fr, es)
- Set them dynamically via `useSeoMeta` in `app.vue` so they are translated per locale

## Test plan
- [ ] Verify `<meta name="description">` changes per locale (`/fr`, `/en`, `/es`)
- [ ] Verify `<meta property="og:image:alt">` changes per locale
- [ ] Run `pnpm lint:fix && pnpm typecheck && pnpm test:run`

Closes #50