### PR TITLE
fix(contact): remove duplicated content section

### DIFF
--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -30,13 +30,6 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'your{\'@\'}email.com',
     organizationPlaceholder: 'Your organization',
     messagePlaceholder: 'Describe your project or question...',
-    whyTitle: 'Why contact us?',
-    whyItem1: 'Get a personalized assessment of your OpenStreetMap data quality needs',
-    whyItem2: 'Discuss deployment options: managed SaaS or self-hosted',
-    whyItem3: 'Learn how Clearance integrates with your existing infrastructure',
-    whyItem4: 'Explore custom validation rules for your specific use case',
-    openSource: 'Clearance is open source (AGPL-3.0). You can explore the code and documentation on {link}.',
-    github: 'GitHub',
   },
   docs: {
     toc: 'On this page',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -30,13 +30,6 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'su{\'@\'}correo.com',
     organizationPlaceholder: 'Su organización',
     messagePlaceholder: 'Describa su proyecto o pregunta...',
-    whyTitle: '¿Por qué contactarnos?',
-    whyItem1: 'Obtenga una evaluación personalizada de sus necesidades de calidad de datos OpenStreetMap',
-    whyItem2: 'Discuta las opciones de despliegue: SaaS gestionado o autoalojado',
-    whyItem3: 'Descubra cómo Clearance se integra con su infraestructura existente',
-    whyItem4: 'Explore reglas de validación personalizadas para su caso de uso',
-    openSource: 'Clearance es open source (AGPL-3.0). Puede explorar el código y la documentación en {link}.',
-    github: 'GitHub',
   },
   docs: {
     toc: 'En esta página',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -30,13 +30,6 @@ export default defineI18nLocale(async () => ({
     emailPlaceholder: 'votre{\'@\'}email.com',
     organizationPlaceholder: 'Votre organisation',
     messagePlaceholder: 'Décrivez votre projet ou votre question...',
-    whyTitle: 'Pourquoi nous contacter ?',
-    whyItem1: 'Obtenez une évaluation personnalisée de vos besoins en qualité de données OpenStreetMap',
-    whyItem2: 'Discutez des options de déploiement : SaaS managé ou auto-hébergé',
-    whyItem3: 'Découvrez comment Clearance s\'intègre à votre infrastructure existante',
-    whyItem4: 'Explorez des règles de validation personnalisées pour votre cas d\'usage',
-    openSource: 'Clearance est open source (AGPL-3.0). Vous pouvez explorer le code et la documentation sur {link}.',
-    github: 'GitHub',
   },
   docs: {
     toc: 'Sur cette page',

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -58,25 +58,6 @@ function onSubmit() {
         </ul>
       </div>
 
-      <div class="mt-8 rounded-lg border border-muted/20 bg-muted/5 p-6">
-        <h2 class="text-lg font-semibold">
-          {{ t('contact.whyTitle') }}
-        </h2>
-        <ul class="mt-3 space-y-1 text-sm text-muted list-disc list-inside">
-          <li>{{ t('contact.whyItem1') }}</li>
-          <li>{{ t('contact.whyItem2') }}</li>
-          <li>{{ t('contact.whyItem3') }}</li>
-          <li>{{ t('contact.whyItem4') }}</li>
-        </ul>
-        <p class="mt-3 text-sm text-muted">
-          <i18n-t keypath="contact.openSource" tag="span">
-            <template #link>
-              <a href="https://github.com/teritorio/clearance" target="_blank" class="text-primary underline">{{ t('contact.github') }}</a>
-            </template>
-          </i18n-t>
-        </p>
-      </div>
-
       <form class="mt-8 space-y-6" @submit.prevent="onSubmit">
         <UFormField :label="t('contact.name')">
           <UInput


### PR DESCRIPTION
## Summary
- Remove the "Pourquoi nous contacter ?" section from the contact page, which was redundant with the "Demander une démonstration" section
- Remove unused i18n keys (`whyTitle`, `whyItem1-4`, `openSource`, `github`) from all 3 locales (fr, en, es)

Closes #52