### PR TITLE
fix(content): clarify replication context in landing page and definitions

### DIFF
--- a/content/en/contact.md
+++ b/content/en/contact.md
@@ -1,4 +1,4 @@
 ---
 title: "Contact - Clearance"
-description: "Contact the Clearance team for a demo, support, or any question about the OpenStreetMap quality filter."
+description: "Contact the Clearance team for a demo, support, or any question about the quality filter for OpenStreetMap replication."
 ---

--- a/content/en/docs/1.getting-started/1.overview.md
+++ b/content/en/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
 title: Clearance Overview
-description: "Discover Clearance, the open source quality filter for OpenStreetMap data. Learn why controlling OSM data quality matters and how Clearance fits into your replication pipeline."
+description: "Discover Clearance, the open source quality filter for your OpenStreetMap replication feed. Learn why quality control during replication matters and how Clearance fits into your pipeline."
 icon: i-lucide-info
 ---
 
@@ -8,7 +8,7 @@ icon: i-lucide-info
 
 ## What is Clearance?
 
-Clearance is an **open source quality filter** for OpenStreetMap data. It sits between the global OpenStreetMap database and your applications to filter and validate changes before they reach your systems.
+Clearance is an **open source quality filter** for your OpenStreetMap replication feed. It sits in the replication pipeline, between the global OpenStreetMap database and your replication tools (osm2pgsql, Imposm, Osmosis), to filter and validate changes before they reach your systems.
 
 ## Reusing OpenStreetMap data with confidence
 

--- a/content/en/docs/index.md
+++ b/content/en/docs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Documentation
-description: Complete documentation for Clearance, the open source quality filter for OpenStreetMap data.
+description: Complete documentation for Clearance, the open source quality filter for your OpenStreetMap replication feed.
 navigation: false
 ---

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -1,13 +1,13 @@
 ---
-title: "Clearance - Quality Filter for OpenStreetMap Data"
-description: "Take control of the quality of the OpenStreetMap data you use or redistribute. Clearance automatically passes compliant changes and holds suspicious ones for review."
+title: "Clearance - Quality Filter for OpenStreetMap Replication"
+description: "Control the quality of your OpenStreetMap replication feed. Clearance automatically passes compliant changes and holds suspicious ones for review."
 ---
 
 ::landing-hero
 ---
-headline: Open source quality filter
-title: Take control of your OpenStreetMap data quality
-description: "Using OpenStreetMap in a critical context? An error can block an emergency route, distort a calculation, or engage your liability. Clearance helps you prevent that."
+headline: Quality filter for OSM replication
+title: Control the quality of your OpenStreetMap replication
+description: "Replicating OpenStreetMap data in a critical context? An unreviewed change can block an emergency route, distort a calculation, or engage your liability. Clearance filters your replication feed before it reaches your systems."
 primaryLabel: View on GitHub
 primaryTo: https://github.com/teritorio/clearance
 secondaryLabel: Request a demo
@@ -18,7 +18,7 @@ secondaryTo: /contact
 ::landing-features
 ---
 headline: Features
-title: Everything you need to secure your OSM data
+title: Everything you need to secure your OSM replication
 description: "A complete quality assurance pipeline between OpenStreetMap and your applications. Clearance never modifies OpenStreetMap: problematic data is simply held, and corrections are made directly in OSM at the source."
 ---
 
@@ -153,7 +153,7 @@ description: "These situations are common when OSM data is used in an operationa
 ---
 headline: Use cases
 title: Who is Clearance for?
-description: Any organization that depends on quality OpenStreetMap data.
+description: Any organization that replicates OpenStreetMap data in an operational context.
 ---
 
   ::landing-use-case

--- a/content/fr/contact.md
+++ b/content/fr/contact.md
@@ -1,4 +1,4 @@
 ---
 title: "Contact - Clearance"
-description: "Contactez l'équipe Clearance pour une démo, un accompagnement ou toute question sur le filtre qualité OpenStreetMap."
+description: "Contactez l'équipe Clearance pour une démo, un accompagnement ou toute question sur le filtre qualité pour la réplication OpenStreetMap."
 ---

--- a/content/fr/docs/1.getting-started/1.overview.md
+++ b/content/fr/docs/1.getting-started/1.overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Vue d'ensemble de Clearance"
-description: "Découvrez Clearance, le filtre qualité open source pour les données OpenStreetMap. Apprenez pourquoi le contrôle qualité des données OSM est essentiel et comment Clearance s'intègre à votre pipeline."
+description: "Découvrez Clearance, le filtre qualité open source pour votre flux de réplication OpenStreetMap. Apprenez pourquoi le contrôle qualité pendant la réplication est essentiel et comment Clearance s'intègre à votre pipeline."
 icon: i-lucide-info
 ---
 
@@ -8,7 +8,7 @@ icon: i-lucide-info
 
 ## Qu'est-ce que Clearance ?
 
-Clearance est un **filtre qualité open source** pour les données OpenStreetMap. Il s'intercale entre la base de données mondiale OpenStreetMap et vos applications pour filtrer et valider les modifications avant qu'elles n'atteignent vos systèmes.
+Clearance est un **filtre qualité open source** pour votre flux de réplication OpenStreetMap. Il s'intercale dans le pipeline de réplication, entre la base de données mondiale OpenStreetMap et vos outils de réplication (osm2pgsql, Imposm, Osmosis), pour filtrer et valider les modifications avant qu'elles n'atteignent vos systèmes.
 
 ## Réutiliser les données OpenStreetMap avec confiance
 

--- a/content/fr/docs/index.md
+++ b/content/fr/docs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Documentation
-description: Documentation complète de Clearance, le filtre qualité open source pour les données OpenStreetMap.
+description: Documentation complète de Clearance, le filtre qualité open source pour votre flux de réplication OpenStreetMap.
 navigation: false
 ---

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -1,13 +1,13 @@
 ---
-title: "Clearance - Filtre qualité pour les données OpenStreetMap"
-description: "Maîtrisez la qualité des données OpenStreetMap que vous utilisez ou rediffusez. Clearance filtre automatiquement les modifications conformes et retient les changements suspects pour vérification."
+title: "Clearance - Filtre qualité pour la réplication OpenStreetMap"
+description: "Contrôlez la qualité de votre flux de réplication OpenStreetMap. Clearance filtre automatiquement les modifications conformes et retient les changements suspects pour vérification."
 ---
 
 ::landing-hero
 ---
-headline: Filtre qualité open source
-title: Maîtrisez la qualité de vos données OpenStreetMap
-description: "Vous utilisez OpenStreetMap dans un contexte critique ? Une erreur peut bloquer un itinéraire de secours, fausser un calcul ou engager votre responsabilité. Clearance vous aide à vous en prémunir."
+headline: Filtre qualité pour la réplication OSM
+title: Contrôlez la qualité de votre réplication OpenStreetMap
+description: "Vous répliquez des données OpenStreetMap dans un contexte critique ? Une modification non vérifiée peut bloquer un itinéraire de secours, fausser un calcul ou engager votre responsabilité. Clearance filtre votre flux de réplication avant qu'il n'atteigne vos systèmes."
 primaryLabel: Voir sur GitHub
 primaryTo: https://github.com/teritorio/clearance
 secondaryLabel: Demander une démo
@@ -18,7 +18,7 @@ secondaryTo: /contact
 ::landing-features
 ---
 headline: Fonctionnalités
-title: Tout ce qu'il faut pour sécuriser vos données OSM
+title: Tout ce qu'il faut pour sécuriser votre réplication OSM
 description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vos applications. Clearance ne modifie jamais OpenStreetMap : les données problématiques sont mises en attente, et les corrections sont apportées directement dans OSM, à la source."
 ---
 
@@ -153,7 +153,7 @@ description: "Ces situations sont courantes lorsque les données OSM sont utilis
 ---
 headline: Cas d'usage
 title: Pour qui est Clearance ?
-description: Toute organisation qui dépend de données OpenStreetMap de qualité.
+description: Toute organisation qui réplique des données OpenStreetMap dans un contexte opérationnel.
 ---
 
   ::landing-use-case


### PR DESCRIPTION
## Summary

- Update landing pages (FR + EN) to position Clearance as a quality filter **for the OSM replication stream**, not a generic quality tool for OSM data
- Update hero headline, H1, description, features section title, and "who is Clearance for" section to consistently mention replication
- Update overview docs first definition to mention the replication pipeline and downstream tools (osm2pgsql, Imposm, Osmosis)
- Update doc index and contact page descriptions (FR + EN)

## Changed files

8 content files across FR and EN: `index.md`, `docs/index.md`, `docs/1.getting-started/1.overview.md`, `contact.md`

## Test plan

- [x] `pnpm lint:fix` passes
- [x] `pnpm generate` builds successfully (109 routes)
- [ ] Review wording in browser on landing page, overview doc, contact page

Closes #53