### PR TITLE
Remove redundant Clearance home link from navigation

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,40 +1,26 @@
 <script setup lang="ts">
-const props = defineProps<{
-  showHome?: boolean
-}>()
 const { t, locale, locales } = useI18n()
 const switchLocalePath = useSwitchLocalePath()
 const localePath = useLocalePath()
 
-const navItems = computed(() => {
-  const items = []
-  if (props.showHome) {
-    items.push({
-      label: t('nav.home'),
-      icon: 'i-lucide-home',
-      to: localePath('/'),
-    })
-  }
-  items.push(
-    {
-      label: t('nav.docs'),
-      icon: 'i-lucide-book-open',
-      to: localePath('/docs'),
-    },
-    {
-      label: t('nav.contact'),
-      icon: 'i-lucide-mail',
-      to: localePath('/contact'),
-    },
-    {
-      label: t('nav.github'),
-      icon: 'i-lucide-github',
-      to: 'https://github.com/teritorio/clearance',
-      target: '_blank',
-    },
-  )
-  return items
-})
+const navItems = computed(() => [
+  {
+    label: t('nav.docs'),
+    icon: 'i-lucide-book-open',
+    to: localePath('/docs'),
+  },
+  {
+    label: t('nav.contact'),
+    icon: 'i-lucide-mail',
+    to: localePath('/contact'),
+  },
+  {
+    label: t('nav.github'),
+    icon: 'i-lucide-github',
+    to: 'https://github.com/teritorio/clearance',
+    target: '_blank',
+  },
+])
 
 const localeItems = computed(() =>
   (locales.value as Array<{ code: string, name: string }>).map(l => ({

--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -48,7 +48,7 @@ const docsNavigation = computed(() => {
 
 <template>
   <div class="min-h-screen flex flex-col">
-    <AppHeader show-home />
+    <AppHeader />
 
     <UContainer class="flex-1">
       <div class="flex gap-8 py-8">

--- a/tests/components/AppHeader.test.ts
+++ b/tests/components/AppHeader.test.ts
@@ -25,19 +25,10 @@ describe('appHeader', () => {
     expect(html).toContain('https://github.com/teritorio/clearance')
   })
 
-  it('does not show home nav item by default', async () => {
+  it('does not show home nav item in navigation menu', async () => {
     const component = await mountSuspended(AppHeader)
     const html = component.html()
-    // Home icon should not appear in nav when showHome is false
     const homeIconCount = (html.match(/i-lucide:home/g) || []).length
     expect(homeIconCount).toBe(0)
-  })
-
-  it('shows home nav item when showHome prop is true', async () => {
-    const component = await mountSuspended(AppHeader, {
-      props: { showHome: true },
-    })
-    const html = component.html()
-    expect(html).toContain('i-lucide:home')
   })
 })

--- a/tests/pages/slug.test.ts
+++ b/tests/pages/slug.test.ts
@@ -3,19 +3,10 @@ import { describe, expect, it } from 'vitest'
 import SlugPage from '~/pages/[...slug].vue'
 
 describe('slug page', () => {
-  it('applies docs layout when path includes /docs', async () => {
+  it('does not show home icon in navigation on docs pages', async () => {
     const component = await mountSuspended(SlugPage, {
       route: '/fr/docs/getting-started/overview',
     })
-    // Docs layout passes showHome to AppHeader, rendering the home icon
-    expect(component.html()).toContain('i-lucide:home')
-  })
-
-  it('applies default layout for non-docs paths', async () => {
-    const component = await mountSuspended(SlugPage, {
-      route: '/fr/about',
-    })
-    // Default layout does not pass showHome, so no home icon in nav
     expect(component.html()).not.toContain('i-lucide:home')
   })
 


### PR DESCRIPTION
## Summary
- Remove the "Clearance" home link from the navigation bar since the clickable site logo already serves the same purpose
- Remove the `showHome` prop from `AppHeader` and the `show-home` usage in docs layout
- Update related tests

Closes #61