### PR TITLE
Restore layout-switching test coverage in slug tests

### DIFF
--- a/tests/pages/slug.test.ts
+++ b/tests/pages/slug.test.ts
@@ -3,11 +3,20 @@ import { describe, expect, it } from 'vitest'
 import SlugPage from '~/pages/[...slug].vue'
 
 describe('slug page', () => {
-  it('does not show home icon in navigation on docs pages', async () => {
+  it('applies docs layout for docs paths', async () => {
     const component = await mountSuspended(SlugPage, {
       route: '/fr/docs/getting-started/overview',
     })
-    expect(component.html()).not.toContain('i-lucide:home')
+    // Docs layout wraps content in a sidebar layout with <aside> elements
+    expect(component.find('aside').exists()).toBe(true)
+  })
+
+  it('applies default layout for non-docs paths', async () => {
+    const component = await mountSuspended(SlugPage, {
+      route: '/fr/about',
+    })
+    // Default layout has no sidebar
+    expect(component.find('aside').exists()).toBe(false)
   })
 
   it('renders not found message when no page data', async () => {


### PR DESCRIPTION
## Summary
- Replace the weak home-icon assertion (removed in #62) with proper layout-switching tests
- Docs paths assert `<aside>` sidebar presence (docs layout)
- Non-docs paths assert no `<aside>` (default layout)

Closes #63