### PR TITLE
feat(landing): add Problem section between Hero and Features

### DIFF
--- a/components/content/LandingProblem.vue
+++ b/components/content/LandingProblem.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  headline?: string
+  title?: string
+}>()
+</script>
+
+<template>
+  <section class="py-16 sm:py-24 bg-zinc-50">
+    <UContainer>
+      <LandingSectionHeader :headline="headline" :title="title" />
+      <div class="mt-12 mx-auto max-w-2xl text-center text-lg text-muted">
+        <MDCSlot :use="$slots.default" />
+      </div>
+    </UContainer>
+  </section>
+</template>

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -15,6 +15,14 @@ secondaryTo: /contact
 ---
 ::
 
+::landing-problem
+---
+headline: The challenge
+title: How can you reuse OpenStreetMap data with confidence?
+---
+OpenStreetMap is constantly evolving. Every day, millions of changes are made by a global community: volunteers, public institutions, and businesses. This dynamism is a strength, but when this data becomes critical for a service, how do you ensure its quality? Traditional replication tools don't include a quality filter — they operate on data that has already been replicated, or at the cost of blocking replication entirely.
+::
+
 ::landing-features
 ---
 headline: Features

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -15,6 +15,14 @@ secondaryTo: /contact
 ---
 ::
 
+::landing-problem
+---
+headline: El desafío
+title: ¿Cómo reutilizar los datos de OpenStreetMap con confianza?
+---
+OpenStreetMap evoluciona constantemente. Cada día, millones de modificaciones son realizadas por una comunidad global: voluntarios, instituciones públicas y empresas. Este dinamismo es una fortaleza, pero cuando estos datos se vuelven críticos para un servicio, ¿cómo garantizar su calidad? Las herramientas clásicas de replicación no incluyen un filtro de calidad — actúan sobre datos ya replicados, o al precio de bloquear la replicación por completo.
+::
+
 ::landing-features
 ---
 headline: Funcionalidades

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -15,6 +15,14 @@ secondaryTo: /contact
 ---
 ::
 
+::landing-problem
+---
+headline: Le défi
+title: Comment réutiliser les données OpenStreetMap avec confiance ?
+---
+OpenStreetMap évolue en permanence. Chaque jour, des millions de modifications sont apportées par une communauté mondiale : bénévoles, institutions publiques et entreprises. Cette dynamique est une force, mais lorsque ces données deviennent critiques pour un service, comment maîtriser leur qualité ? Les outils classiques de réplication n'intègrent pas de filtre qualité — ils interviennent sur des données déjà répliquées, ou au prix d'un blocage de la réplication.
+::
+
 ::landing-features
 ---
 headline: Fonctionnalités


### PR DESCRIPTION
## Summary
- New `LandingProblem.vue` component (same pattern as `LandingReferences.vue` — section header + body via `MDCSlot`, `bg-zinc-50` background)
- Inserted `::landing-problem` section between Hero and Features in FR, EN, and ES content
- Explains why OSM data quality is a challenge (community dynamics, classic tool limitations), serving SEO and user education

Closes #65