### PR TITLE
feat(seo): leverage @nuxtjs/seo capabilities

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -19,11 +19,6 @@ useHead({
 })
 
 useSchemaOrg([
-  defineOrganization({
-    name: 'Teritorio',
-    url: 'https://teritorio.fr',
-    logo: 'https://www.teritorio.fr/wp-content/themes/teritorio/assets/images/favicon/favicon-194x194.png',
-  }),
   defineSoftwareApp({
     name: 'Clearance',
     operatingSystem: 'Any',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,25 @@ export default defineNuxtConfig({
     url: 'https://clearance.teritorio.xyz',
     name: 'Clearance',
     defaultLocale: 'fr',
+    trailingSlash: false,
+  },
+
+  schemaOrg: {
+    identity: {
+      type: 'Organization',
+      name: 'Teritorio',
+      url: 'https://teritorio.fr',
+      logo: 'https://www.teritorio.fr/wp-content/themes/teritorio/assets/images/favicon/favicon-194x194.png',
+    },
+  },
+
+  sitemap: {
+    autoLastmod: true,
+  },
+
+  linkChecker: {
+    runOnBuild: true,
+    failOnError: true,
   },
 
   ogImage: {


### PR DESCRIPTION
## Summary
- Move `defineOrganization` from `app.vue` to `schemaOrg.identity` config in `nuxt.config.ts`
- Add `sitemap.autoLastmod` for automatic `<lastmod>` timestamps in sitemap entries
- Add `linkChecker` with `runOnBuild` + `failOnError` to catch broken links at build time
- Set `trailingSlash: false` for canonical URL consistency

## Test plan
- [x] `pnpm dev` starts without errors, 0 TypeScript errors
- [x] `pnpm generate` succeeds, link checker runs (0 errors, 6 pre-existing warnings)
- [x] `robots.txt` and `sitemap_index.xml` generated with `<lastmod>` timestamps
- [x] Lint passes clean

Closes #67