### PR TITLE
feat(landing): invert Hero CTA order

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -8,10 +8,10 @@ description: "Control the quality of your OpenStreetMap replication feed. Cleara
 headline: Quality filter for OSM replication
 title: Control the quality of your OpenStreetMap replication
 description: "Replicating OpenStreetMap data in a critical context? An unreviewed change can block an emergency route, distort a calculation, or engage your liability. Clearance is open source software that filters your replication feed before it reaches your systems."
-primaryLabel: View on GitHub
-primaryTo: https://github.com/teritorio/clearance
-secondaryLabel: Request a demo
-secondaryTo: /contact
+primaryLabel: Request a demo
+primaryTo: /contact
+secondaryLabel: View on GitHub
+secondaryTo: https://github.com/teritorio/clearance
 ---
 ::
 

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -8,10 +8,10 @@ description: "Controle la calidad de su flujo de replicación OpenStreetMap. Cle
 headline: Filtro de calidad para la replicación OSM
 title: Controle la calidad de su replicación OpenStreetMap
 description: "¿Replica datos OpenStreetMap en un contexto crítico? Un cambio no verificado puede bloquear una ruta de emergencia, falsear un cálculo o comprometer su responsabilidad. Clearance es un software libre que filtra su flujo de replicación antes de que llegue a sus sistemas."
-primaryLabel: Ver en GitHub
-primaryTo: https://github.com/teritorio/clearance
-secondaryLabel: Solicitar una demo
-secondaryTo: /contact
+primaryLabel: Solicitar una demo
+primaryTo: /contact
+secondaryLabel: Ver en GitHub
+secondaryTo: https://github.com/teritorio/clearance
 ---
 ::
 

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -8,10 +8,10 @@ description: "Contrôlez la qualité de votre flux de réplication OpenStreetMap
 headline: Filtre qualité pour la réplication OSM
 title: Contrôlez la qualité de votre réplication OpenStreetMap
 description: "Vous répliquez des données OpenStreetMap dans un contexte critique ? Une modification non vérifiée peut bloquer un itinéraire de secours, fausser un calcul ou engager votre responsabilité. Clearance est un logiciel libre qui filtre votre flux de réplication avant qu'il n'atteigne vos systèmes."
-primaryLabel: Voir sur GitHub
-primaryTo: https://github.com/teritorio/clearance
-secondaryLabel: Demander une démo
-secondaryTo: /contact
+primaryLabel: Demander une démo
+primaryTo: /contact
+secondaryLabel: Voir sur GitHub
+secondaryTo: https://github.com/teritorio/clearance
 ---
 ::
 


### PR DESCRIPTION
## Summary
- Swap Hero CTAs: "Request a demo" becomes the primary (solid) button, "View on GitHub" becomes secondary (outline)

Closes #71