### PR TITLE
Merge use cases into single section with 7 target audiences

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -133,74 +133,65 @@ description: "A complete quality assurance pipeline between OpenStreetMap and yo
 
 ::landing-use-cases
 ---
-headline: Concrete examples
-title: Rules adapted to your business
-description: "These situations are common when OSM data is used in an operational context."
+headline: Use cases
+title: Who is Clearance for?
+description: "Clearance is designed for organizations that regularly use OpenStreetMap data with quality requirements."
 ---
 
   ::landing-use-case
   ---
-  icon: i-lucide-heart-pulse
-  title: Defibrillator moved
-  ---
-  A defibrillator relocation could engage your liability if the published information is incorrect.
-  ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-route
-  title: Road network modified
+  icon: i-lucide-bus
+  title: Mobility and transport operators
   ---
   A road segment modification can disrupt a route calculator used by your services.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-construction
-  title: Facility not yet operational
+  icon: i-lucide-shield-alert
+  title: Emergency and security services
   ---
-  Adding a public facility that is not yet operational can lead to premature public use.
+  A defibrillator relocation could engage your liability if the published information is incorrect.
   ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-link-2-off
-  title: Reference deleted
-  ---
-  Deleting a reference can break joins with a business database and cause malfunctions.
-  ::
-
-::
-
-::landing-use-cases
----
-headline: Use cases
-title: Who is Clearance for?
-description: Any organization that replicates OpenStreetMap data in an operational context.
----
 
   ::landing-use-case
   ---
   icon: i-lucide-map
   title: Local authorities
   ---
-  Ensure the reliability of map data used in your digital public services.
+  Adding a public facility that is not yet operational can lead to premature public use.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-bus
-  title: Transport operators
+  icon: i-lucide-tree-pine
+  title: Natural park managers
   ---
-  Guarantee the quality of stop and network data for your passenger applications.
+  The removal or modification of a marked trail can endanger hikers following your routes.
   ::
 
   ::landing-use-case
   ---
   icon: i-lucide-landmark
-  title: Tourism offices
+  title: Destination management organizations
   ---
-  Maintain up-to-date and reliable points of interest for your visitors.
+  A poorly referenced tourist point of interest can degrade the experience of visitors to your territory.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-database
+  title: Territorial open data platforms
+  ---
+  Deleting a reference can break joins with a business database and cause malfunctions.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-layers
+  title: Mapping application developers
+  ---
+  Inconsistent source data can cause display or navigation anomalies in your application.
   ::
 
 ::

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -133,74 +133,65 @@ description: "Un pipeline completo de aseguramiento de calidad entre OpenStreetM
 
 ::landing-use-cases
 ---
-headline: Ejemplos concretos
-title: Reglas adaptadas a su actividad
-description: "Estas situaciones son frecuentes cuando los datos OSM se utilizan en un contexto operativo."
+headline: Casos de uso
+title: ¿Para quién es Clearance?
+description: "Clearance está diseñado para organizaciones que utilizan regularmente los datos de OpenStreetMap con exigencias de calidad."
 ---
 
   ::landing-use-case
   ---
-  icon: i-lucide-heart-pulse
-  title: Desfibrilador desplazado
-  ---
-  El desplazamiento de un desfibrilador podría comprometer su responsabilidad si la información difundida es errónea.
-  ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-route
-  title: Red vial modificada
+  icon: i-lucide-bus
+  title: Operadores de movilidad y transporte
   ---
   La modificación de un segmento de red vial puede perturbar un calculador de rutas utilizado por sus servicios.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-construction
-  title: Equipamiento no operativo
+  icon: i-lucide-shield-alert
+  title: Servicios de emergencia y seguridad
   ---
-  La adición de un equipamiento público aún no operativo puede generar un uso prematuro por parte del público.
+  El desplazamiento de un desfibrilador podría comprometer su responsabilidad si la información difundida es errónea.
   ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-link-2-off
-  title: Referencia eliminada
-  ---
-  La eliminación de una referencia puede romper las uniones con una base de datos de negocio y provocar disfunciones.
-  ::
-
-::
-
-::landing-use-cases
----
-headline: Casos de uso
-title: ¿Para quién es Clearance?
-description: Cualquier organización que replique datos OpenStreetMap en un contexto operativo.
----
 
   ::landing-use-case
   ---
   icon: i-lucide-map
   title: Administraciones locales
   ---
-  Asegure la fiabilidad de los datos cartográficos utilizados en sus servicios públicos digitales.
+  La adición de un equipamiento público aún no operativo puede generar un uso prematuro por parte del público.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-bus
-  title: Operadores de transporte
+  icon: i-lucide-tree-pine
+  title: Gestores de parques naturales
   ---
-  Garantice la calidad de los datos de paradas y redes para sus aplicaciones de viajeros.
+  La eliminación o modificación de un sendero señalizado puede poner en peligro a los excursionistas que siguen sus rutas.
   ::
 
   ::landing-use-case
   ---
   icon: i-lucide-landmark
-  title: Oficinas de turismo
+  title: Organismos de gestión de destinos
   ---
-  Mantenga puntos de interés actualizados y fiables para sus visitantes.
+  Un punto de interés turístico mal referenciado puede degradar la experiencia de los visitantes de su territorio.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-database
+  title: Plataformas territoriales de datos abiertos
+  ---
+  La eliminación de una referencia puede romper las uniones con una base de datos de negocio y provocar disfunciones.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-layers
+  title: Desarrolladores de aplicaciones cartográficas
+  ---
+  Datos fuente inconsistentes pueden generar anomalías de visualización o navegación en su aplicación.
   ::
 
 ::

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -133,74 +133,65 @@ description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vo
 
 ::landing-use-cases
 ---
-headline: Exemples concrets
-title: Des règles adaptées à votre métier
-description: "Ces situations sont courantes lorsque les données OSM sont utilisées dans un contexte opérationnel."
+headline: Cas d'usage
+title: Pour qui est Clearance ?
+description: "Clearance s'adresse aux organisations qui utilisent régulièrement les données d'OpenStreetMap avec des exigences de qualité."
 ---
 
   ::landing-use-case
   ---
-  icon: i-lucide-heart-pulse
-  title: Défibrillateur déplacé
-  ---
-  Un déplacement d'un défibrillateur pourrait engager votre responsabilité si l'information diffusée est erronée.
-  ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-route
-  title: Réseau routier modifié
+  icon: i-lucide-bus
+  title: Opérateurs de mobilité et de transport
   ---
   La modification d'un segment de réseau routier peut perturber un calculateur d'itinéraire utilisé par vos services.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-construction
-  title: Équipement pas encore opérationnel
+  icon: i-lucide-shield-alert
+  title: Services de secours et de sécurité
   ---
-  L'ajout d'un équipement public pas encore opérationnel peut générer un usage prématuré par le public.
+  Un déplacement d'un défibrillateur pourrait engager votre responsabilité si l'information diffusée est erronée.
   ::
-
-  ::landing-use-case
-  ---
-  icon: i-lucide-link-2-off
-  title: Référence supprimée
-  ---
-  La suppression d'une référence peut rompre les jointures avec une base métier et provoquer des dysfonctionnements.
-  ::
-
-::
-
-::landing-use-cases
----
-headline: Cas d'usage
-title: Pour qui est Clearance ?
-description: Toute organisation qui réplique des données OpenStreetMap dans un contexte opérationnel.
----
 
   ::landing-use-case
   ---
   icon: i-lucide-map
   title: Collectivités territoriales
   ---
-  Assurez la fiabilité des données cartographiques utilisées dans vos services publics numériques.
+  L'ajout d'un équipement public pas encore opérationnel peut générer un usage prématuré par le public.
   ::
 
   ::landing-use-case
   ---
-  icon: i-lucide-bus
-  title: Opérateurs de transport
+  icon: i-lucide-tree-pine
+  title: Gestionnaires de parcs naturels
   ---
-  Garantissez la qualité des données d'arrêts et de réseaux pour vos applications voyageurs.
+  La suppression ou la modification d'un sentier balisé peut mettre en danger les randonneurs qui suivent vos itinéraires.
   ::
 
   ::landing-use-case
   ---
   icon: i-lucide-landmark
-  title: Offices de tourisme
+  title: Organismes de gestion de destination
   ---
-  Maintenez des points d'intérêt à jour et fiables pour vos visiteurs.
+  Un point d'intérêt touristique mal référencé peut dégrader l'expérience des visiteurs de votre territoire.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-database
+  title: Plateformes territoriales de données open data
+  ---
+  La suppression d'une référence peut rompre les jointures avec une base métier et provoquer des dysfonctionnements.
+  ::
+
+  ::landing-use-case
+  ---
+  icon: i-lucide-layers
+  title: Concepteurs d'applications cartographiques
+  ---
+  Une donnée source incohérente peut générer des anomalies d'affichage ou de navigation dans votre application.
   ::
 
 ::


### PR DESCRIPTION
## Summary
- Consolidate the two `landing-use-cases` sections ("Exemples concrets" + "Cas d'usage") into a single unified section
- List 7 target audiences, each with a concrete example description reused from the former "Exemples concrets" cards
- 4 descriptions reused from existing content, 3 new ones written in the same style
- Updated across all 3 locales (FR, EN, ES)

## Target audiences
1. Opérateurs de mobilité et de transport
2. Services de secours et de sécurité
3. Collectivités territoriales
4. Gestionnaires de parcs naturels
5. Organismes de gestion de destination
6. Plateformes territoriales de données open data
7. Concepteurs d'applications cartographiques

## Test plan
- [ ] Visual check on all 3 locales (FR, EN, ES)
- [ ] Verify the section renders 7 cards with correct icons
- [ ] Confirm the "Exemples concrets" section is no longer present

Closes #74