### PR TITLE
Redesign features section with two-column layout

### DIFF
--- a/components/content/LandingPractice.vue
+++ b/components/content/LandingPractice.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+defineProps<{
+  headline?: string
+  title?: string
+  description?: string
+}>()
+</script>
+
+<template>
+  <section class="py-16 sm:py-24">
+    <UContainer>
+      <div class="grid gap-12 lg:grid-cols-2 lg:items-center">
+        <div>
+          <div v-if="title">
+            <p v-if="headline" class="text-sm font-semibold text-primary">
+              {{ headline }}
+            </p>
+            <h2 class="mt-2 text-3xl font-bold tracking-tight sm:text-4xl">
+              {{ title }}
+            </h2>
+            <p v-if="description" class="mt-4 text-lg text-muted">
+              {{ description }}
+            </p>
+          </div>
+          <div class="mt-10 flex flex-col gap-6">
+            <MDCSlot :use="$slots.default" />
+          </div>
+        </div>
+        <div class="flex min-h-[300px] items-center justify-center rounded-2xl border-2 border-dashed border-zinc-300 bg-zinc-50 p-12">
+          <div class="text-center text-sm text-muted">
+            <UIcon name="i-lucide-image" class="mb-2 size-10 text-zinc-300" />
+            <p>Image</p>
+          </div>
+        </div>
+      </div>
+    </UContainer>
+  </section>
+</template>

--- a/components/content/LandingPracticeItem.vue
+++ b/components/content/LandingPracticeItem.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+defineProps<{
+  icon?: string
+  title?: string
+}>()
+</script>
+
+<template>
+  <div class="flex items-start gap-4">
+    <div v-if="icon" class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+      <UIcon :name="icon" class="size-6 text-primary" />
+    </div>
+    <div>
+      <h3 v-if="title" class="text-base font-semibold">
+        {{ title }}
+      </h3>
+      <div class="text-sm text-muted [&_p]:m-0" :class="{ 'mt-1': title }">
+        <MDCSlot :use="$slots.default" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -74,14 +74,14 @@ description: "Clearance never modifies OpenStreetMap. Problematic data is simply
 
 ::
 
-::landing-features
+::landing-practice
 ---
 headline: In practice
 title: Everything you need to secure your OSM replication
 description: "A complete quality assurance pipeline between OpenStreetMap and your applications, while continuing to contribute to the OpenStreetMap commons."
 ---
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-map-pin
   title: Territory and collaboration
@@ -89,7 +89,7 @@ description: "A complete quality assurance pipeline between OpenStreetMap and yo
   Define territorial and thematic projects on which your team collaborates to monitor and maintain data quality.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-list-checks
   title: Rules adapted to your business
@@ -97,36 +97,12 @@ description: "A complete quality assurance pipeline between OpenStreetMap and yo
   Apply controls tailored to your needs: relocations, deletions, premature additions, broken joins, and more.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-database
   title: Quality proxy
   ---
   Uses standard OpenStreetMap ecosystem formats for input and output. Continue using your tools with greater data confidence.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-shield-check
-  title: Quality filter
-  ---
-  Automatically integrates compliant changes while holding suspicious modifications for human review.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-scan-search
-  title: Semantic analysis
-  ---
-  Checks OSM tag consistency and detects potentially problematic changes before they reach your systems.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-code-2
-  title: Open source
-  ---
-  Clearance is open source software under the AGPL-3.0 license. Deploy it on your infrastructure or opt for our SaaS offering.
   ::
 
 ::

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -74,14 +74,14 @@ description: "Clearance nunca modifica OpenStreetMap. Los datos problemáticos s
 
 ::
 
-::landing-features
+::landing-practice
 ---
 headline: En la práctica
 title: Todo lo necesario para asegurar su replicación OSM
 description: "Un pipeline completo de aseguramiento de calidad entre OpenStreetMap y sus aplicaciones, mientras continúa contribuyendo al bien común OpenStreetMap."
 ---
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-map-pin
   title: Territorio y colaboración
@@ -89,7 +89,7 @@ description: "Un pipeline completo de aseguramiento de calidad entre OpenStreetM
   Defina proyectos territoriales y temáticos en los que su equipo colabore para monitorear y mantener la calidad de los datos.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-list-checks
   title: Reglas adaptadas a su actividad
@@ -97,36 +97,12 @@ description: "Un pipeline completo de aseguramiento de calidad entre OpenStreetM
   Aplique controles adaptados a su necesidad: desplazamientos, eliminaciones, adiciones prematuras, rupturas de uniones y más.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-database
   title: Proxy de calidad
   ---
   Utiliza los formatos estándar del ecosistema OpenStreetMap tanto de entrada como de salida. Siga usando sus herramientas con mayor confianza en los datos.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-shield-check
-  title: Filtro de calidad
-  ---
-  Integra automáticamente los cambios conformes mientras retiene las modificaciones sospechosas para revisión humana.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-scan-search
-  title: Análisis semántico
-  ---
-  Verifica la coherencia de los tags OSM y detecta cambios potencialmente problemáticos antes de que lleguen a sus sistemas.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-code-2
-  title: Software libre
-  ---
-  Clearance es software libre bajo licencia AGPL-3.0. Despliéguelo en su infraestructura u opte por nuestra oferta SaaS.
   ::
 
 ::

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -74,14 +74,14 @@ description: "Clearance ne modifie jamais OpenStreetMap. Les données problémat
 
 ::
 
-::landing-features
+::landing-practice
 ---
 headline: En pratique
 title: Tout ce qu'il faut pour sécuriser votre réplication OSM
 description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vos applications, tout en continuant à contribuer au commun OpenStreetMap."
 ---
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-map-pin
   title: Territoire et collaboration
@@ -89,7 +89,7 @@ description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vo
   Définissez des projets territoriaux et thématiques sur lesquels votre équipe collabore pour suivre et maintenir la qualité des données.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-list-checks
   title: Règles adaptées à votre métier
@@ -97,36 +97,12 @@ description: "Un pipeline complet d'assurance qualité entre OpenStreetMap et vo
   Appliquez des contrôles adaptés à votre besoin : déplacements, suppressions, ajouts prématurés, ruptures de jointures et bien plus.
   ::
 
-  ::landing-feature
+  ::landing-practice-item
   ---
   icon: i-lucide-database
   title: Proxy qualité
   ---
   Utilise en entrée comme en sortie les formats standard de l'écosystème OpenStreetMap. Continuez à utiliser vos outils avec un meilleur niveau de confiance.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-shield-check
-  title: Filtre qualité
-  ---
-  Intègre automatiquement les modifications conformes tout en retenant les changements suspects pour vérification humaine.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-scan-search
-  title: Analyse sémantique
-  ---
-  Vérifie la cohérence des tags OSM et détecte les modifications potentiellement problématiques avant qu'elles n'atteignent vos systèmes.
-  ::
-
-  ::landing-feature
-  ---
-  icon: i-lucide-code-2
-  title: Logiciel libre
-  ---
-  Clearance est un logiciel libre sous licence AGPL-3.0. Déployez-le sur votre infrastructure ou optez pour notre offre SaaS.
   ::
 
 ::


### PR DESCRIPTION
## Summary

- Create new `LandingPractice` and `LandingPracticeItem` components for the "En pratique" section
- Two-column layout: left column has section header (left-aligned) + vertical list of items (icon + title + description), right column has an image placeholder (to be replaced later)
- Update all 3 locale content files (fr, en, es) to use the new components
- Existing `LandingFeatures` / `LandingFeature` components are left untouched

## Test plan

- [ ] Run `pnpm dev` and visually check the "En pratique" section
- [ ] Verify responsive behavior: stacked on mobile, two-column on `lg:` breakpoint
- [ ] Confirm all 3 locales (fr, en, es) render correctly
- [ ] Verify other sections using `LandingFeatures`/`LandingFeature` are unaffected

Closes #76