### PR TITLE
docs(i18n): rename nav label from 'Documentation' to 'How it works?'

### DIFF
--- a/content/en/docs/index.md
+++ b/content/en/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Documentation
-description: Complete documentation for Clearance, the open source quality filter for your OpenStreetMap replication feed.
+title: How it works?
+description: Learn how Clearance works, the open source quality filter for your OpenStreetMap replication feed.
 navigation: false
 ---

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -226,7 +226,7 @@ title: Request a demonstration
 description: "During a demonstration, we discuss your context and needs, present how Clearance works, illustrate concrete use cases, and share our roadmap."
 primaryLabel: Contact us
 primaryTo: /contact
-secondaryLabel: Documentation
+secondaryLabel: How it works?
 secondaryTo: /docs
 ---
 ::

--- a/content/es/docs/index.md
+++ b/content/es/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Documentación
-description: Documentación completa de Clearance, el filtro de calidad open source para su flujo de replicación OpenStreetMap.
+title: ¿Cómo funciona?
+description: Descubra cómo funciona Clearance, el filtro de calidad open source para su flujo de replicación OpenStreetMap.
 navigation: false
 ---

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -226,7 +226,7 @@ title: Solicitar una demostración
 description: "Durante una demostración, intercambiamos sobre su contexto y necesidades, presentamos el funcionamiento de Clearance, ilustramos casos de uso concretos y compartimos nuestra hoja de ruta."
 primaryLabel: Contáctenos
 primaryTo: /contact
-secondaryLabel: Documentación
+secondaryLabel: ¿Cómo funciona?
 secondaryTo: /docs
 ---
 ::

--- a/content/fr/docs/index.md
+++ b/content/fr/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Documentation
-description: Documentation complète de Clearance, le filtre qualité open source pour votre flux de réplication OpenStreetMap.
+title: Comment ça marche ?
+description: Découvrez le fonctionnement de Clearance, le filtre qualité open source pour votre flux de réplication OpenStreetMap.
 navigation: false
 ---

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -226,7 +226,7 @@ title: Demander une démonstration
 description: "Lors d'une démonstration, nous échangeons sur votre contexte et vos besoins, vous présentons le fonctionnement de Clearance, illustrons des cas d'usage concrets et partageons notre feuille de route."
 primaryLabel: Nous contacter
 primaryTo: /contact
-secondaryLabel: Documentation
+secondaryLabel: Comment ça marche ?
 secondaryTo: /docs
 ---
 ::

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -1,7 +1,7 @@
 export default defineI18nLocale(async () => ({
   nav: {
     home: 'Clearance',
-    docs: 'Documentation',
+    docs: 'How it works?',
     contact: 'Contact',
     github: 'GitHub',
     changeLanguage: 'Change language',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -1,7 +1,7 @@
 export default defineI18nLocale(async () => ({
   nav: {
     home: 'Clearance',
-    docs: 'Documentación',
+    docs: '¿Cómo funciona?',
     contact: 'Contacto',
     github: 'GitHub',
     changeLanguage: 'Cambiar idioma',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -1,7 +1,7 @@
 export default defineI18nLocale(async () => ({
   nav: {
     home: 'Clearance',
-    docs: 'Documentation',
+    docs: 'Comment ça marche ?',
     contact: 'Contact',
     github: 'GitHub',
     changeLanguage: 'Changer de langue',


### PR DESCRIPTION
## Summary
- Rename navigation label across all 3 locales: FR → "Comment ça marche ?", EN → "How it works?", ES → "¿Cómo funciona?"
- Update docs index page titles and descriptions to match
- Update landing page CTA `secondaryLabel` in all locales

Closes #84