### PR TITLE
docs(en): translate 'how-it-works' section to English

### DIFF
--- a/content/en/docs/1.how-it-works/1.replication.md
+++ b/content/en/docs/1.how-it-works/1.replication.md
@@ -1,4 +1,22 @@
 ---
 title: OSM Replication
-description: How Clearance creates a synchronized and controlled local copy of OpenStreetMap data.
+description: "Clearance implements a partial OpenStreetMap replication under quality constraints: a synchronized and controlled local copy."
+icon: i-lucide-refresh-cw
 ---
+
+# OSM replication under quality constraints
+
+Clearance lets you implement a **partial OpenStreetMap replication under quality constraints**.
+
+An initial OSM extract is loaded locally, then updates are retrieved continuously. They are not applied immediately: they are first analyzed. Only the changes that comply with the rules defined for your area of interest and your targeted themes are integrated.
+
+You thus obtain a **local OSM copy** that is:
+
+- **Synchronized** — updates are continuously retrieved from the OpenStreetMap replication feed
+- **Controlled** — only changes that comply with your quality rules are integrated
+
+## See also
+
+- [Geographic Context (LoCha)](/en/docs/how-it-works/locha) — How Clearance groups changes for coherent validation
+- [Control Rules](/en/docs/how-it-works/rules) — The configurable rules that filter changes
+- [Integration Guide](/en/docs/going-further/integration) — Integrate Clearance into your infrastructure

--- a/content/en/docs/1.how-it-works/2.locha.md
+++ b/content/en/docs/1.how-it-works/2.locha.md
@@ -1,4 +1,29 @@
 ---
 title: Geographic Context (LoCha)
-description: How Clearance uses geographic context for change validation.
+description: "Clearance groups OSM changes into geographically coherent sets (LoCha) for contextual validation, rather than object by object."
+icon: i-lucide-map-pin
 ---
+
+# Contextual change validation
+
+The challenge is not just detecting that an object has changed, but **understanding what that change actually means**.
+
+In OpenStreetMap, modifications are contributed in changesets that are not always coherent from a geographic, thematic, or temporal standpoint. These changes are then broadcast in chronological order, no longer grouped by changeset. Moreover, a single object can be deleted, recreated, split, or merged. It therefore becomes necessary to reorganize this flow of changes in order to analyze it.
+
+Clearance does not validate changes solely object by object, nor changeset by changeset, nor in chronological order. It **groups them into geographically coherent sets**.
+
+## Geographic context of changes (LoCha)
+
+Clearance introduces the concept of **Logical Changeset** (LoCha).
+
+OSM modifications at the same location must all be accepted or all rejected at the same time, to guarantee a coherent state of the local copy.
+
+::callout{type="info"}
+**TODO**: add an example
+::
+
+## See also
+
+- [OSM Replication](/en/docs/how-it-works/replication) — The synchronized and controlled local copy mechanism
+- [Semantic Reading](/en/docs/how-it-works/semantic) — How Clearance interprets the meaning of modifications
+- [Feedback Loop](/en/docs/how-it-works/feedback-loop) — The correction and acceptance cycle for changes

--- a/content/en/docs/1.how-it-works/3.semantic.md
+++ b/content/en/docs/1.how-it-works/3.semantic.md
@@ -1,4 +1,29 @@
 ---
 title: Semantic Reading
-description: How Clearance interprets the meaning of OpenStreetMap changes.
+description: "Clearance reconstructs a semantic history of business objects from OSM to validate changes at the business level, not per technical object."
+icon: i-lucide-brain
 ---
+
+# A semantic reading of changes
+
+Clearance does not evaluate changes OSM object by OSM object, because **the technical history of OSM objects is not a business history**. Technical modifications can be arbitrary and without semantic traceability: merges, geometry splits, moving some tags to another object, etc.
+
+Clearance reconstructs a **semantic history of business objects** based on:
+
+- **Semantic similarity** carried by OSM tags
+- **Geographic proximity** between OSM objects
+- **Business references** when they exist
+
+This makes it possible to validate changes at the business level rather than per technical OSM object.
+
+Depending on the configuration, this limits the changes to evaluate, or even to correct, to only take into account what actually has a **business impact**.
+
+::callout{type="info"}
+**TODO**: add an example, or two (geom, tags)
+::
+
+## See also
+
+- [Geographic Context (LoCha)](/en/docs/how-it-works/locha) — Geographic grouping of changes
+- [Control Rules](/en/docs/how-it-works/rules) — The concrete rules that leverage this semantic reading
+- [Feedback Loop](/en/docs/how-it-works/feedback-loop) — What happens when a change is held back

--- a/content/en/docs/1.how-it-works/4.rules.md
+++ b/content/en/docs/1.how-it-works/4.rules.md
@@ -1,4 +1,47 @@
 ---
 title: Control Rules
-description: The concrete and configurable rules that filter OpenStreetMap changes.
+description: "Clearance's concrete and configurable rules: delayed, deleted, duplicate, geom, network, tags, and user_list."
+icon: i-lucide-list-checks
 ---
+
+# Concrete and configurable control rules
+
+The goal is to hold back suspicious modifications, i.e., those that do not meet quality criteria. Quality is evaluated using OSM tag properties, metadata, geometry, and changeset properties.
+
+## Validators
+
+The currently implemented validators are:
+
+### delayed
+
+Holds back recent changes for a delay, to allow contested or still-evolving modifications to stabilize.
+
+### deleted
+
+Holds back deleted objects.
+
+### duplicate
+
+Holds back duplicate object additions.
+
+### geom
+
+Holds back objects whose geometry modification exceeds a certain threshold.
+
+### network
+
+Holds back objects that lose or gain connectivity to a network (road network, electrical grid, etc.).
+
+### tags
+
+Holds back objects based on the key and value of their tags.
+
+### user_list
+
+Holds back objects based on the contributor's name (whitelist or blacklist).
+
+## See also
+
+- [Semantic Reading](/en/docs/how-it-works/semantic) — How Clearance interprets the meaning of modifications before applying rules
+- [Feedback Loop](/en/docs/how-it-works/feedback-loop) — What happens when a rule holds back a change
+- [Deployment](/en/docs/going-further/deployment) — Configure and deploy Clearance with your rules

--- a/content/en/docs/1.how-it-works/5.feedback-loop.md
+++ b/content/en/docs/1.how-it-works/5.feedback-loop.md
@@ -1,4 +1,29 @@
 ---
 title: Feedback Loop
-description: The correction and acceptance cycle for changes in Clearance.
+description: "The correction and acceptance cycle for changes in Clearance: correction in OSM or manual acceptance."
+icon: i-lucide-repeat
 ---
+
+# A continuous improvement loop
+
+When a change does not pass the quality rules, it is not lost: it is **held back for review**.
+
+Two outcomes are then possible:
+
+## Correction in OpenStreetMap
+
+A correction is made in OpenStreetMap. At the next update, if the affected objects become compliant, the accumulated changes are **automatically integrated** into the local database.
+
+## Manual acceptance
+
+The modification is deemed valid by the user despite the flag. It is **manually accepted** and integrated into the local database.
+
+---
+
+This approach maintains a stable OSM copy, in which the quality of integrated changes is controlled, **without requiring a full resynchronization**.
+
+## See also
+
+- [Control Rules](/en/docs/how-it-works/rules) — The rules that trigger change retention
+- [Geographic Context (LoCha)](/en/docs/how-it-works/locha) — Why changes are accepted or rejected as a group
+- [OSM Replication](/en/docs/how-it-works/replication) — The overall controlled local copy mechanism

--- a/content/en/docs/1.how-it-works/6.roadmap.md
+++ b/content/en/docs/1.how-it-works/6.roadmap.md
@@ -1,4 +1,27 @@
 ---
 title: Roadmap
-description: Upcoming developments for Clearance.
+description: "Upcoming developments for Clearance: cross-referencing with external sources, external quality rules, and contributor reputation."
+icon: i-lucide-compass
 ---
+
+# Upcoming developments
+
+Some of the ongoing developments are currently funded by the **NLNet** foundation. But other major developments are also planned.
+
+## Cross-referencing with external data sources
+
+Flag discrepancies between OSM and other business or OpenData data sources.
+
+## External quality rules
+
+Validate changes using external quality rules (JOSM validator, Osmose-QA...).
+
+## Contributor reputation
+
+Take into account the "reputation" of contributors (beginner, flagged for bad contributions, statistical analyses) and changes (changeset discussions...).
+
+## See also
+
+- [OSM Replication](/en/docs/how-it-works/replication) — How Clearance currently works
+- [Control Rules](/en/docs/how-it-works/rules) — Currently implemented validators
+- [References](/en/docs/going-further/references) — Organizations already using Clearance


### PR DESCRIPTION
## Summary
- Translate all 6 'how-it-works' documentation pages from FR to EN
- Pages: replication, locha, semantic, rules, feedback-loop, roadmap
- Preserves Markdown structure, icons, callout TODOs, and cross-links

Closes #87