### PR TITLE
docs(es): translate 'how-it-works' section to Spanish

### DIFF
--- a/content/es/docs/1.how-it-works/1.replication.md
+++ b/content/es/docs/1.how-it-works/1.replication.md
@@ -1,4 +1,22 @@
 ---
 title: Replicación OSM
-description: Cómo Clearance crea una copia local sincronizada y controlada de los datos de OpenStreetMap.
+description: "Clearance implementa una replicación parcial de OpenStreetMap bajo restricciones de calidad: una copia local sincronizada y controlada."
+icon: i-lucide-refresh-cw
 ---
+
+# Una replicación OSM bajo restricciones de calidad
+
+Clearance le permite implementar una **replicación parcial de OpenStreetMap bajo restricciones de calidad**.
+
+Un extracto inicial de OSM se carga localmente, luego las actualizaciones se recuperan de forma continua. No se aplican inmediatamente: primero se analizan. Solo se integran los cambios que cumplen con las reglas definidas para su zona de interés y sus temáticas objetivo.
+
+Así obtiene una **copia local OSM**:
+
+- **Sincronizada** — las actualizaciones se recuperan continuamente desde el flujo de replicación de OpenStreetMap
+- **Controlada** — solo se integran los cambios que cumplen con sus reglas de calidad
+
+## Ver también
+
+- [Contexto geográfico (LoCha)](/es/docs/how-it-works/locha) — Cómo Clearance agrupa los cambios para una validación coherente
+- [Reglas de control](/es/docs/how-it-works/rules) — Las reglas configurables que filtran los cambios
+- [Guía de integración](/es/docs/going-further/integration) — Integrar Clearance en su infraestructura

--- a/content/es/docs/1.how-it-works/2.locha.md
+++ b/content/es/docs/1.how-it-works/2.locha.md
@@ -1,4 +1,29 @@
 ---
 title: Contexto geográfico (LoCha)
-description: Cómo Clearance utiliza el contexto geográfico para la validación de cambios.
+description: "Clearance agrupa los cambios OSM en conjuntos geográficamente coherentes (LoCha) para una validación contextual, y no objeto por objeto."
+icon: i-lucide-map-pin
 ---
+
+# Una validación contextual de los cambios
+
+La dificultad no es solo detectar que un objeto ha cambiado, sino **comprender lo que realmente significa ese cambio**.
+
+En OpenStreetMap, las modificaciones se contribuyen en changesets que no siempre son coherentes desde el punto de vista geográfico, temático o temporal. Estos cambios se difunden luego en orden cronológico, ya no agrupados por changeset. Además, un mismo objeto puede ser eliminado, recreado, dividido o fusionado. Por lo tanto, se hace necesario reorganizar este flujo de cambios para poder analizarlo.
+
+Clearance no valida los cambios únicamente objeto por objeto, ni changeset por changeset, ni en orden cronológico. Los **agrupa en conjuntos coherentes en el plano geográfico**.
+
+## Contexto geográfico de los cambios (LoCha)
+
+Clearance introduce el concepto de **grupo de cambios lógicos** (LoCha — _Logical Changeset_).
+
+Las modificaciones de OSM en el mismo lugar deben ser todas aceptadas o todas rechazadas al mismo tiempo, para garantizar un estado coherente de la copia local.
+
+::callout{type="info"}
+**TODO**: agregar un ejemplo
+::
+
+## Ver también
+
+- [Replicación OSM](/es/docs/how-it-works/replication) — El mecanismo de copia local sincronizada y controlada
+- [Lectura semántica](/es/docs/how-it-works/semantic) — Cómo Clearance interpreta el significado de las modificaciones
+- [Bucle de mejora](/es/docs/how-it-works/feedback-loop) — El ciclo de corrección y aceptación de cambios

--- a/content/es/docs/1.how-it-works/3.semantic.md
+++ b/content/es/docs/1.how-it-works/3.semantic.md
@@ -1,4 +1,29 @@
 ---
 title: Lectura semántica
-description: Cómo Clearance interpreta el significado de los cambios en OpenStreetMap.
+description: "Clearance reconstruye un historial semántico de los objetos de negocio OSM para validar los cambios a nivel de negocio, no por objeto técnico."
+icon: i-lucide-brain
 ---
+
+# Una lectura semántica de los cambios
+
+Clearance no evalúa los cambios objeto OSM por objeto OSM, porque **el historial técnico de los objetos OSM no es un historial de negocio**. Las modificaciones técnicas pueden ser arbitrarias y sin trazabilidad semántica: fusiones, divisiones de geometrías, desplazamiento de parte de los tags hacia otro objeto, etc.
+
+Clearance reconstruye un **historial semántico de los objetos de negocio** basándose en:
+
+- **La similaridad semántica** portada por los tags OSM
+- **La proximidad geográfica** entre los objetos OSM
+- **La consideración de referencias de negocio** cuando existen
+
+Esto permite validar los cambios a nivel de negocio y no por objeto técnico OSM.
+
+Según la configuración, esto limita los cambios a evaluar, o incluso a corregir, para tomar en cuenta solo lo que realmente tiene un **impacto en el negocio**.
+
+::callout{type="info"}
+**TODO**: agregar un ejemplo, o dos (geom, tags)
+::
+
+## Ver también
+
+- [Contexto geográfico (LoCha)](/es/docs/how-it-works/locha) — La agrupación geográfica de los cambios
+- [Reglas de control](/es/docs/how-it-works/rules) — Las reglas concretas que aprovechan esta lectura semántica
+- [Bucle de mejora](/es/docs/how-it-works/feedback-loop) — Qué sucede cuando un cambio es retenido

--- a/content/es/docs/1.how-it-works/4.rules.md
+++ b/content/es/docs/1.how-it-works/4.rules.md
@@ -1,4 +1,47 @@
 ---
 title: Reglas de control
-description: Las reglas concretas y configurables que filtran los cambios de OpenStreetMap.
+description: "Las reglas concretas y configurables de Clearance: delayed, deleted, duplicate, geom, network, tags y user_list."
+icon: i-lucide-list-checks
 ---
+
+# Reglas de control concretas y configurables
+
+El objetivo es retener las modificaciones sospechosas, es decir, aquellas que no cumplen con los criterios de calidad. La calidad se evalúa utilizando las propiedades de los tags OSM, los metadatos, la geometría y las propiedades del changeset.
+
+## Validadores
+
+Los validadores actualmente implementados son:
+
+### delayed
+
+Retiene los cambios recientes durante un plazo, para dejar tiempo a que las modificaciones contestadas o aún en evolución se estabilicen.
+
+### deleted
+
+Retiene los objetos eliminados.
+
+### duplicate
+
+Retiene las adiciones de objetos duplicados.
+
+### geom
+
+Retiene los objetos cuya modificación de geometría supera un determinado umbral.
+
+### network
+
+Retiene los objetos que pierden o ganan conectividad a una red (red vial, red eléctrica, etc.).
+
+### tags
+
+Retiene los objetos según la clave y el valor de sus tags.
+
+### user_list
+
+Retiene los objetos según el nombre del contribuidor (lista blanca o lista negra).
+
+## Ver también
+
+- [Lectura semántica](/es/docs/how-it-works/semantic) — Cómo Clearance interpreta el significado de las modificaciones antes de aplicar las reglas
+- [Bucle de mejora](/es/docs/how-it-works/feedback-loop) — Qué sucede cuando una regla retiene un cambio
+- [Despliegue](/es/docs/going-further/deployment) — Configurar y desplegar Clearance con sus reglas

--- a/content/es/docs/1.how-it-works/5.feedback-loop.md
+++ b/content/es/docs/1.how-it-works/5.feedback-loop.md
@@ -1,4 +1,29 @@
 ---
 title: Bucle de mejora
-description: El ciclo de corrección y aceptación de cambios en Clearance.
+description: "El ciclo de corrección y aceptación de cambios en Clearance: corrección en OSM o aceptación manual."
+icon: i-lucide-repeat
 ---
+
+# Un bucle de mejora continua
+
+Cuando un cambio no pasa las reglas de calidad, no se pierde: se **retiene para revisión**.
+
+Dos casos son entonces posibles:
+
+## Corrección en OpenStreetMap
+
+Se realiza una corrección en OpenStreetMap. En la siguiente actualización, si los objetos afectados se vuelven conformes, los cambios acumulados se **integran automáticamente** en la base local.
+
+## Aceptación manual
+
+La modificación es considerada válida por el usuario a pesar de la señalización. Se **acepta manualmente** y se integra en la base local.
+
+---
+
+Este enfoque permite mantener una copia OSM estable, en la que la calidad de los cambios integrados está controlada, **sin necesidad de una resincronización completa**.
+
+## Ver también
+
+- [Reglas de control](/es/docs/how-it-works/rules) — Las reglas que desencadenan la retención de un cambio
+- [Contexto geográfico (LoCha)](/es/docs/how-it-works/locha) — Por qué los cambios se aceptan o rechazan por grupo
+- [Replicación OSM](/es/docs/how-it-works/replication) — El mecanismo global de copia local controlada

--- a/content/es/docs/1.how-it-works/6.roadmap.md
+++ b/content/es/docs/1.how-it-works/6.roadmap.md
@@ -1,4 +1,27 @@
 ---
 title: Hoja de ruta
-description: Las próximas evoluciones de Clearance.
+description: "Las próximas evoluciones de Clearance: cruce con fuentes externas, reglas de calidad externas y reputación de los contribuidores."
+icon: i-lucide-compass
 ---
+
+# Evoluciones futuras
+
+Una parte de las evoluciones en curso está actualmente financiada por la fundación **NLNet**. Pero otras evoluciones importantes también están previstas.
+
+## Cruce con fuentes de datos externas
+
+Señalar las discrepancias entre OSM y otras fuentes de datos de negocio u OpenData.
+
+## Reglas de calidad externas
+
+Validar los cambios apoyándose en reglas de calidad externas (validador JOSM, Osmose-QA...).
+
+## Reputación de los contribuidores
+
+Tomar en cuenta la "reputación" de los contribuidores (principiante, señalado por malas contribuciones, análisis estadísticos) y de los cambios (discusiones de changeset...).
+
+## Ver también
+
+- [Replicación OSM](/es/docs/how-it-works/replication) — El funcionamiento actual de Clearance
+- [Reglas de control](/es/docs/how-it-works/rules) — Los validadores actualmente implementados
+- [Referencias](/es/docs/going-further/references) — Las organizaciones que ya utilizan Clearance


### PR DESCRIPTION
## Summary
- Translate all 6 'how-it-works' documentation pages from FR to ES
- Pages: replication, locha, semantic, rules, feedback-loop, roadmap
- Preserves Markdown structure, icons, callout TODOs, and cross-links

Closes #88