### PR TITLE
docs: update cross-links in 'going-further' section

### DIFF
--- a/content/en/docs/2.going-further/1.integration.md
+++ b/content/en/docs/2.going-further/1.integration.md
@@ -53,5 +53,5 @@ To configure integration with your infrastructure, see the [GitHub repository](h
 ## See also
 
 - [Deployment options](/en/docs/going-further/deployment) — SaaS managed service or self-hosted
-- [How Clearance works](/en/docs/getting-started/how-it-works) — Understand the validation pipeline
-- [Validation rules](/en/docs/getting-started/rules) — Configure rules for your quality needs
+- [Geographic Context (LoCha)](/en/docs/how-it-works/locha) — Understand the validation pipeline
+- [Control Rules](/en/docs/how-it-works/rules) — Configure rules for your quality needs

--- a/content/en/docs/2.going-further/3.references.md
+++ b/content/en/docs/2.going-further/3.references.md
@@ -40,6 +40,6 @@ Do you use Clearance and want to be listed as a reference? [Contact us](/en/cont
 
 ## See also
 
-- [Clearance Overview](/en/docs/getting-started/overview) — What Clearance is and how it works
+- [OSM Replication](/en/docs/how-it-works/replication) — What Clearance is and how it works
 - [Deployment options](/en/docs/going-further/deployment) — Get started with SaaS or self-hosted
-- [Roadmap](/en/docs/going-further/roadmap) — Upcoming features and development plans
+- [Roadmap](/en/docs/how-it-works/roadmap) — Upcoming features and development plans

--- a/content/es/docs/2.going-further/1.integration.md
+++ b/content/es/docs/2.going-further/1.integration.md
@@ -53,5 +53,5 @@ Para configurar la integración con su infraestructura, consulte el [repositorio
 ## Ver también
 
 - [Opciones de despliegue](/es/docs/going-further/deployment) — Compare las opciones SaaS gestionado y autoalojado para desplegar Clearance
-- [Cómo funciona Clearance](/es/docs/getting-started/how-it-works) — Comprenda el flujo de validación que alimenta estas salidas
-- [Reglas de validación](/es/docs/getting-started/rules) — Configure las reglas que determinan qué cambios se validan automáticamente
+- [Contexto geográfico (LoCha)](/es/docs/how-it-works/locha) — Comprenda el flujo de validación que alimenta estas salidas
+- [Reglas de control](/es/docs/how-it-works/rules) — Configure las reglas que determinan qué cambios se validan automáticamente

--- a/content/es/docs/2.going-further/3.references.md
+++ b/content/es/docs/2.going-further/3.references.md
@@ -40,6 +40,6 @@ La fundación **NLNet** también financia parte de los desarrollos mediante fond
 
 ## Ver también
 
-- [Descripción general de Clearance](/es/docs/getting-started/overview) — Qué es Clearance y por qué el control de calidad de datos OSM es esencial
+- [Replicación OSM](/es/docs/how-it-works/replication) — Qué es Clearance y por qué el control de calidad de datos OSM es esencial
 - [Opciones de despliegue](/es/docs/going-further/deployment) — Compare las opciones SaaS gestionado y autoalojado para desplegar Clearance
-- [Hoja de ruta](/es/docs/going-further/roadmap) — Explore las próximas funcionalidades y mejoras planificadas
+- [Hoja de ruta](/es/docs/how-it-works/roadmap) — Explore las próximas funcionalidades y mejoras planificadas

--- a/content/fr/docs/2.going-further/1.integration.md
+++ b/content/fr/docs/2.going-further/1.integration.md
@@ -53,5 +53,5 @@ Pour configurer l'intégration avec votre infrastructure, consultez le [dépôt 
 ## Voir aussi
 
 - [Options de déploiement](/fr/docs/going-further/deployment) — Choisir entre SaaS managé et auto-hébergé
-- [Fonctionnement de Clearance](/fr/docs/getting-started/how-it-works) — Comprendre le flux de validation en amont de l'intégration
-- [Règles de validation](/fr/docs/getting-started/rules) — Configurer les règles qui alimentent les sorties
+- [Contexte géographique (LoCha)](/fr/docs/how-it-works/locha) — Comprendre le flux de validation en amont de l'intégration
+- [Règles de contrôle](/fr/docs/how-it-works/rules) — Configurer les règles qui alimentent les sorties

--- a/content/fr/docs/2.going-further/3.references.md
+++ b/content/fr/docs/2.going-further/3.references.md
@@ -40,6 +40,6 @@ Vous utilisez Clearance et souhaitez apparaître comme référence ? [Contactez-
 
 ## Voir aussi
 
-- [Vue d'ensemble de Clearance](/fr/docs/getting-started/overview) — Comprendre ce qu'est Clearance et comment il fonctionne
+- [Réplication OSM](/fr/docs/how-it-works/replication) — Comprendre ce qu'est Clearance et comment il fonctionne
 - [Options de déploiement](/fr/docs/going-further/deployment) — Choisir le modèle de déploiement adapté à votre organisation
-- [Feuille de route](/fr/docs/going-further/roadmap) — Découvrir les fonctionnalités à venir
+- [Feuille de route](/fr/docs/how-it-works/roadmap) — Découvrir les fonctionnalités à venir


### PR DESCRIPTION
## Summary
- Fix broken cross-links in `going-further/` pages after directory restructure
- `getting-started/*` → `how-it-works/*` (integration + references, all 3 locales)
- `going-further/roadmap` → `how-it-works/roadmap` (references, all 3 locales)

Closes #89