### PR TITLE
fix(content): convert validators to bullet list on control rules page

### DIFF
--- a/content/en/docs/1.how-it-works/4.rules.md
+++ b/content/en/docs/1.how-it-works/4.rules.md
@@ -12,30 +12,10 @@ The goal is to hold back suspicious modifications, i.e., those that do not meet 
 
 The currently implemented validators are:
 
-### delayed
-
-Holds back recent changes for a delay, to allow contested or still-evolving modifications to stabilize.
-
-### deleted
-
-Holds back deleted objects.
-
-### duplicate
-
-Holds back duplicate object additions.
-
-### geom
-
-Holds back objects whose geometry modification exceeds a certain threshold.
-
-### network
-
-Holds back objects that lose or gain connectivity to a network (road network, electrical grid, etc.).
-
-### tags
-
-Holds back objects based on the key and value of their tags.
-
-### user_list
-
-Holds back objects based on the contributor's name (whitelist or blacklist).
+- **delayed** — Holds back recent changes for a delay, to allow contested or still-evolving modifications to stabilize.
+- **deleted** — Holds back deleted objects.
+- **duplicate** — Holds back duplicate object additions.
+- **geom** — Holds back objects whose geometry modification exceeds a certain threshold.
+- **network** — Holds back objects that lose or gain connectivity to a network (road network, electrical grid, etc.).
+- **tags** — Holds back objects based on the key and value of their tags.
+- **user_list** — Holds back objects based on the contributor's name (whitelist or blacklist).

--- a/content/es/docs/1.how-it-works/4.rules.md
+++ b/content/es/docs/1.how-it-works/4.rules.md
@@ -12,30 +12,10 @@ El objetivo es retener las modificaciones sospechosas, es decir, aquellas que no
 
 Los validadores actualmente implementados son:
 
-### delayed
-
-Retiene los cambios recientes durante un plazo, para dejar tiempo a que las modificaciones contestadas o aún en evolución se estabilicen.
-
-### deleted
-
-Retiene los objetos eliminados.
-
-### duplicate
-
-Retiene las adiciones de objetos duplicados.
-
-### geom
-
-Retiene los objetos cuya modificación de geometría supera un determinado umbral.
-
-### network
-
-Retiene los objetos que pierden o ganan conectividad a una red (red vial, red eléctrica, etc.).
-
-### tags
-
-Retiene los objetos según la clave y el valor de sus tags.
-
-### user_list
-
-Retiene los objetos según el nombre del contribuidor (lista blanca o lista negra).
+- **delayed** — Retiene los cambios recientes durante un plazo, para dejar tiempo a que las modificaciones contestadas o aún en evolución se estabilicen.
+- **deleted** — Retiene los objetos eliminados.
+- **duplicate** — Retiene las adiciones de objetos duplicados.
+- **geom** — Retiene los objetos cuya modificación de geometría supera un determinado umbral.
+- **network** — Retiene los objetos que pierden o ganan conectividad a una red (red vial, red eléctrica, etc.).
+- **tags** — Retiene los objetos según la clave y el valor de sus tags.
+- **user_list** — Retiene los objetos según el nombre del contribuidor (lista blanca o lista negra).

--- a/content/fr/docs/1.how-it-works/4.rules.md
+++ b/content/fr/docs/1.how-it-works/4.rules.md
@@ -12,30 +12,10 @@ L'objectif est de retenir les modifications suspectes, c'est-à-dire celles qui 
 
 Les validateurs actuellement implémentés sont :
 
-### delayed
-
-Retient les changements récents pendant un délai, afin de laisser le temps aux modifications contestées ou encore en cours d'évolution de se stabiliser.
-
-### deleted
-
-Retient les objets supprimés.
-
-### duplicate
-
-Retient les ajouts d'objets en doublon.
-
-### geom
-
-Retient les objets dont la modification de géométrie dépasse un certain seuil.
-
-### network
-
-Retient les objets qui perdent ou gagnent une connectivité à un réseau (voirie, réseau électrique, etc.).
-
-### tags
-
-Retient les objets selon la clé et la valeur de leurs tags.
-
-### user_list
-
-Retient les objets selon le nom du contributeur (liste blanche ou liste noire).
+- **delayed** — Retient les changements récents pendant un délai, afin de laisser le temps aux modifications contestées ou encore en cours d'évolution de se stabiliser.
+- **deleted** — Retient les objets supprimés.
+- **duplicate** — Retient les ajouts d'objets en doublon.
+- **geom** — Retient les objets dont la modification de géométrie dépasse un certain seuil.
+- **network** — Retient les objets qui perdent ou gagnent une connectivité à un réseau (voirie, réseau électrique, etc.).
+- **tags** — Retient les objets selon la clé et la valeur de leurs tags.
+- **user_list** — Retient les objets selon le nom du contributeur (liste blanche ou liste noire).


### PR DESCRIPTION
## Summary
- Replaces h3 headings + paragraphs with a bullet list for the Validators section on the control rules docs page
- Applied across all three locales (en/fr/es)

## Test plan
- [ ] Visual: validators display as a compact list instead of separate heading+paragraph blocks

Closes #116