### PR TITLE
feat(ui): add mobile sidebar navigation for docs layout

### DIFF
--- a/layouts/docs.vue
+++ b/layouts/docs.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
-const { locale } = useI18n()
+const { t, locale } = useI18n()
+
+const route = useRoute()
+const mobileNavOpen = ref(false)
+
+watch(() => route.path, () => {
+  mobileNavOpen.value = false
+})
 
 const head = useLocaleHead({ seo: true })
 useHead({
@@ -63,6 +70,15 @@ const docsNavigation = computed(() => {
         </aside>
 
         <main class="min-w-0 flex-1">
+          <div class="mb-4 lg:hidden">
+            <UButton
+              icon="i-lucide-menu"
+              variant="outline"
+              color="neutral"
+              :label="t('nav.docs')"
+              @click="mobileNavOpen = true"
+            />
+          </div>
           <slot />
         </main>
 
@@ -73,6 +89,16 @@ const docsNavigation = computed(() => {
         </aside>
       </div>
     </UContainer>
+
+    <USlideover v-model:open="mobileNavOpen" side="left" :title="t('nav.docs')">
+      <template #body>
+        <UContentNavigation
+          v-if="docsNavigation.length"
+          :navigation="docsNavigation"
+          highlight
+        />
+      </template>
+    </USlideover>
 
     <AppFooter />
   </div>


### PR DESCRIPTION
## Summary
- Adds a menu button visible below `lg:` breakpoint at the top of docs content
- Opens a `USlideover` (left side) containing the same `UContentNavigation` with docs navigation
- Auto-closes on route change

## Test plan
- [x] `pnpm lint:fix` — clean
- [x] `pnpm test:run` — 45 tests pass
- [ ] Visual check: menu button appears on mobile/tablet, hidden on desktop
- [ ] Visual check: slideover opens with navigation, closes on link click

Closes #119