### PR TITLE
fix(content): use exact plan text for solution section

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -45,8 +45,8 @@ description: "When OpenStreetMap data becomes critical for a service, a question
 headline: The solution
 title: "Clearance: an OSM replication tool with a built-in quality filter"
 description: "Clearance never modifies OpenStreetMap. Problematic data is simply held, and corrections are to be made directly in OSM at the source."
-intro: "Clearance acts as a continuous improvement tool for your local copy of OpenStreetMap. It monitors changes and classifies them automatically."
-conclusion: "You get an up-to-date version, reliable and adapted to your quality requirements."
+intro: "Clearance acts as a continuous improvement tool for your local copy, adapted to your business needs:"
+conclusion: "You get an up-to-date version of OpenStreetMap data, reliable for your needs and adapted to your quality requirements, while continuing to contribute to the OpenStreetMap commons."
 changesLabel: Changes
 osmLabel: OpenStreetMap
 clearanceLabel: Clearance
@@ -67,7 +67,7 @@ feedbackLabel: Corrections in OSM
   icon: i-lucide-pause-circle
   title: Sensitive modifications
   ---
-  Sensitive modifications are held for review and, if needed, correction in OSM.
+  Sensitive modifications are held for review and, if needed, correction in OSM. On the next check, if everything is compliant, modifications will pass the filter and be integrated into the local copy.
   ::
 
 ::

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -45,8 +45,8 @@ description: "Cuando los datos de OpenStreetMap se vuelven críticos para un ser
 headline: La solución
 title: "Clearance: una herramienta de replicación OSM con filtro de calidad integrado"
 description: "Clearance nunca modifica OpenStreetMap. Los datos problemáticos simplemente se retienen, y las correcciones se han de realizar directamente en OSM, en la fuente."
-intro: "Clearance actúa como una herramienta de mejora continua de su copia local de OpenStreetMap. Supervisa los cambios y los clasifica automáticamente."
-conclusion: "Así dispone de una versión actualizada, fiable y adaptada a sus requisitos de calidad."
+intro: "Clearance actúa como una herramienta de mejora continua de su copia local, adaptada a sus necesidades profesionales:"
+conclusion: "Así dispone de una versión actualizada de los datos de OpenStreetMap, fiable para sus usos y adaptada a sus requisitos de calidad, mientras continúa contribuyendo al bien común OpenStreetMap."
 changesLabel: Cambios
 osmLabel: OpenStreetMap
 clearanceLabel: Clearance
@@ -67,7 +67,7 @@ feedbackLabel: Correcciones en OSM
   icon: i-lucide-pause-circle
   title: Modificaciones sensibles
   ---
-  Las modificaciones sensibles se retienen para verificación y, si es necesario, corrección en OSM.
+  Las modificaciones sensibles se retienen para verificación y, si es necesario, corrección en OSM. En la siguiente verificación, si todo es conforme, las modificaciones pasarán el filtro y se integrarán a la copia local.
   ::
 
 ::

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -45,8 +45,8 @@ description: "Lorsque les données OpenStreetMap deviennent critiques pour un se
 headline: La solution
 title: "Clearance : un outil de réplication OSM doté d'un filtre qualité"
 description: "Clearance ne modifie jamais OpenStreetMap. Les données problématiques sont simplement mises en attente, et les corrections sont à apporter directement dans OSM, à la source."
-intro: "Clearance agit comme un outil d'amélioration continue de votre copie locale d'OpenStreetMap. Il surveille les changements et les classe automatiquement."
-conclusion: "Vous disposez ainsi d'une version à jour, fiable et adaptée à vos contraintes de qualité."
+intro: "Clearance agit comme un outil d'amélioration continue de votre copie locale, adapté à vos usages métier :"
+conclusion: "Vous disposez ainsi d'une version à jour des données OpenStreetMap, fiable pour vos usages et adaptée à vos contraintes de qualité, tout en continuant à contribuer au commun OpenStreetMap."
 changesLabel: Changements
 osmLabel: OpenStreetMap
 clearanceLabel: Clearance
@@ -67,7 +67,7 @@ feedbackLabel: Corrections dans OSM
   icon: i-lucide-pause-circle
   title: Modifications sensibles
   ---
-  Les modifications sensibles sont mises en attente pour vérification et, si nécessaire, correction dans OSM.
+  Les modifications sensibles sont mises en attente pour vérification et, si nécessaire, correction dans OSM. Au prochain contrôle si tout est conforme, les modifications passeront le filtre et seront intégrées à la copie locale.
   ::
 
 ::


### PR DESCRIPTION
## Summary

- Restore `intro`, `conclusion`, and card 2 body text to match the original plan specification
- FR: exact text from plan transcript
- EN/ES: faithful translations of the FR plan text

### Changes per locale

**intro** — was generic ("monitors changes and classifies them"), now matches plan ("adapted to your business needs:")

**conclusion** — was truncated, now includes full text ("while continuing to contribute to the OpenStreetMap commons")

**card 2 body** — was missing second sentence about next check passing the filter

## Test plan

- [x] `pnpm lint:fix` — clean
- [x] `pnpm test:run` — 46 tests pass