### PR TITLE
feat(ui): add card containment to practice items

### DIFF
--- a/components/content/LandingPracticeItem.vue
+++ b/components/content/LandingPracticeItem.vue
@@ -6,16 +6,18 @@ defineProps<{
 </script>
 
 <template>
-  <div class="flex items-start gap-4">
-    <div v-if="icon" class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-      <UIcon :name="icon" class="size-6 text-primary" />
-    </div>
-    <div>
-      <h3 v-if="title" class="text-base font-semibold">
-        {{ title }}
-      </h3>
-      <div class="text-sm text-muted [&_p]:m-0" :class="{ 'mt-1': title }">
-        <MDCSlot :use="$slots.default" />
+  <div class="rounded-xl border border-zinc-200 bg-zinc-50 p-4 sm:p-6">
+    <div class="flex items-start gap-4">
+      <div v-if="icon" class="flex size-12 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+        <UIcon :name="icon" class="size-6 text-primary" />
+      </div>
+      <div>
+        <h3 v-if="title" class="text-base font-semibold">
+          {{ title }}
+        </h3>
+        <div class="text-sm text-muted [&_p]:m-0" :class="{ 'mt-1': title }">
+          <MDCSlot :use="$slots.default" />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Wrap each `LandingPracticeItem` in a rounded card with border and subtle background (`rounded-xl border border-zinc-200 bg-zinc-50`)
- Matches the existing `LandingFeature` card style for visual consistency
- Gives the "En pratique" section structure and makes varying content heights look intentional

Closes #136