### PR TITLE
feat(ui): stack practice items as rows instead of columns

### DIFF
--- a/components/content/LandingPractice.vue
+++ b/components/content/LandingPractice.vue
@@ -11,7 +11,7 @@ defineProps<{
     <UContainer>
       <LandingSectionHeader :headline="headline" :title="title" :description="description" />
 
-      <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="mx-auto mt-10 grid max-w-3xl gap-6">
         <MDCSlot :use="$slots.default" />
       </div>
     </UContainer>


### PR DESCRIPTION
## Summary
- Replace `sm:grid-cols-2 lg:grid-cols-3` with single-column stacked layout
- Center with `mx-auto max-w-3xl` for comfortable reading width
- Each card gets full width, better for the "Rules" card with its bullet list

Closes #138