### PR TITLE
fix(content): remove mapping app developers use case

### DIFF
--- a/content/en/index.md
+++ b/content/en/index.md
@@ -165,14 +165,6 @@ description: "Clearance is designed for organizations that regularly use OpenStr
   Deleting a reference can break joins with a business database and cause malfunctions.
   ::
 
-  ::landing-use-case
-  ---
-  icon: i-lucide-layers
-  title: Mapping application developers
-  ---
-  Inconsistent source data can cause display or navigation anomalies in your application.
-  ::
-
 ::
 
 ::landing-references

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -165,14 +165,6 @@ description: "Clearance está diseñado para organizaciones que utilizan regular
   La eliminación de una referencia puede romper las uniones con una base de datos de negocio y provocar disfunciones.
   ::
 
-  ::landing-use-case
-  ---
-  icon: i-lucide-layers
-  title: Desarrolladores de aplicaciones cartográficas
-  ---
-  Datos fuente inconsistentes pueden generar anomalías de visualización o navegación en su aplicación.
-  ::
-
 ::
 
 ::landing-references

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -165,14 +165,6 @@ description: "Clearance s'adresse aux organisations qui utilisent régulièremen
   La suppression d'une référence peut rompre les jointures avec une base métier et provoquer des dysfonctionnements.
   ::
 
-  ::landing-use-case
-  ---
-  icon: i-lucide-layers
-  title: Concepteurs d'applications cartographiques
-  ---
-  Une donnée source incohérente peut générer des anomalies d'affichage ou de navigation dans votre application.
-  ::
-
 ::
 
 ::landing-references


### PR DESCRIPTION
## Summary
- Remove the "Concepteurs d'applications cartographiques" use case from FR, EN, and ES landing pages

Closes #140