### PR TITLE
fix(utils): extract docs sections from locale children

### DIFF
--- a/tests/utils/docs-sections.test.ts
+++ b/tests/utils/docs-sections.test.ts
@@ -2,27 +2,42 @@ import { describe, expect, it } from 'vitest'
 import { extractDocsSections, findNavigationNode } from '~/utils/docs-sections'
 
 describe('extractDocsSections', () => {
-  it('returns slugs of nodes that have children', () => {
+  it('returns slugs of sections that have children under locale root', () => {
     const navigation = [
-      { path: '/fr/how-it-works', children: [{ path: '/fr/how-it-works/replication' }] },
-      { path: '/fr/contact' },
+      {
+        path: '/fr',
+        children: [
+          { path: '/fr/how-it-works', children: [{ path: '/fr/how-it-works/replication' }] },
+          { path: '/fr/contact' },
+        ],
+      },
     ]
     expect(extractDocsSections(navigation)).toEqual(['how-it-works'])
   })
 
   it('returns multiple sections when several have children', () => {
     const navigation = [
-      { path: '/fr/how-it-works', children: [{ path: '/fr/how-it-works/replication' }] },
-      { path: '/fr/guides', children: [{ path: '/fr/guides/setup' }] },
-      { path: '/fr/contact' },
+      {
+        path: '/fr',
+        children: [
+          { path: '/fr/how-it-works', children: [{ path: '/fr/how-it-works/replication' }] },
+          { path: '/fr/guides', children: [{ path: '/fr/guides/setup' }] },
+          { path: '/fr/contact' },
+        ],
+      },
     ]
     expect(extractDocsSections(navigation)).toEqual(['how-it-works', 'guides'])
   })
 
-  it('returns an empty array when no nodes have children', () => {
+  it('returns an empty array when no sections have children', () => {
     const navigation = [
-      { path: '/fr/contact' },
-      { path: '/fr/about' },
+      {
+        path: '/fr',
+        children: [
+          { path: '/fr/contact' },
+          { path: '/fr/about' },
+        ],
+      },
     ]
     expect(extractDocsSections(navigation)).toEqual([])
   })
@@ -31,10 +46,15 @@ describe('extractDocsSections', () => {
     expect(extractDocsSections([])).toEqual([])
   })
 
-  it('ignores nodes with empty children arrays', () => {
+  it('ignores sections with empty children arrays', () => {
     const navigation = [
-      { path: '/fr/how-it-works', children: [] },
-      { path: '/fr/contact' },
+      {
+        path: '/fr',
+        children: [
+          { path: '/fr/how-it-works', children: [] },
+          { path: '/fr/contact' },
+        ],
+      },
     ]
     expect(extractDocsSections(navigation)).toEqual([])
   })

--- a/utils/docs-sections.ts
+++ b/utils/docs-sections.ts
@@ -4,7 +4,9 @@ export interface NavigationNode {
 }
 
 export function extractDocsSections(navigation: NavigationNode[]): string[] {
-  return navigation
+  // Navigation tree has a locale root node (e.g. /fr) with sections as children
+  const sections = navigation.flatMap(node => node.children ?? [])
+  return sections
     .filter(node => node.children?.length)
     .map(node => node.path.split('/').pop()!)
 }


### PR DESCRIPTION
## Summary

- Fix `extractDocsSections` to look at children of the locale root node instead of the top level
- `queryCollectionNavigation` returns `[{ path: '/fr', children: [...sections] }]`, not `[...sections]` directly
- Update tests to match the real navigation tree structure

Closes #183

## Test plan

- [x] `pnpm generate` with `NUXT_APP_BASE_URL=/clearance-website/` produces HTML with sidebar (`<aside>`, `sticky top-20`)
- [x] All tests pass (updated to reflect real navigation structure)
- [ ] Verify sidebar renders on GitHub Pages