### PR TITLE
chore: update app URLs to app.clearance.teritorio.xyz and configure custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Generate static site
         run: pnpm generate
-        env:
-          NUXT_APP_BASE_URL: /clearance-website/
 
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const APP_URL = 'https://clearance.teritorio.xyz'
+const APP_URL = 'https://app.clearance.teritorio.xyz'
 
 const { t } = useI18n()
 const localePath = useLocalePath()

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -166,7 +166,7 @@ headline: References
 title: Over 40 organizations already use Clearance
 description: "To reuse OpenStreetMap data with greater confidence."
 ctaLabel: Example project on Clearance
-ctaTo: https://clearance.teritorio.xyz/france_landes_poi/changes_logs
+ctaTo: https://app.clearance.teritorio.xyz/france_landes_poi/changes_logs
 ---
 
   ::landing-reference

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -166,7 +166,7 @@ headline: Referencias
 title: Más de 40 organizaciones ya utilizan Clearance
 description: "Para reutilizar los datos de OpenStreetMap con mayor confianza."
 ctaLabel: Ejemplo de proyecto en Clearance
-ctaTo: https://clearance.teritorio.xyz/france_landes_poi/changes_logs
+ctaTo: https://app.clearance.teritorio.xyz/france_landes_poi/changes_logs
 ---
 
   ::landing-reference

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -166,7 +166,7 @@ headline: Références
 title: Plus de 40 organisations utilisent déjà Clearance
 description: "Pour réutiliser les données OpenStreetMap avec davantage de confiance."
 ctaLabel: Exemple de projet sur Clearance
-ctaTo: https://clearance.teritorio.xyz/france_landes_poi/changes_logs
+ctaTo: https://app.clearance.teritorio.xyz/france_landes_poi/changes_logs
 ---
 
   ::landing-reference

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+clearance.teritorio.xyz

--- a/tests/components/AppHeader.test.ts
+++ b/tests/components/AppHeader.test.ts
@@ -28,7 +28,7 @@ describe('appHeader', () => {
   it('renders See Clearance CTA button with correct URL', async () => {
     const component = await mountSuspended(AppHeader)
     const html = component.html()
-    expect(html).toContain('https://clearance.teritorio.xyz')
+    expect(html).toContain('https://app.clearance.teritorio.xyz')
     expect(html).toContain('See Clearance')
   })
 


### PR DESCRIPTION
## Summary

- Update all `clearance.teritorio.xyz` app links to `app.clearance.teritorio.xyz` (AppHeader, CTA in content pages, tests)
- Remove `NUXT_APP_BASE_URL: /clearance-website/` from deploy workflow (site will be served at root of custom domain)
- Add `public/CNAME` file for GitHub Pages custom domain `clearance.teritorio.xyz`

Closes #186

## Test plan

- [x] All 60 tests pass
- [ ] Verify links in AppHeader point to `app.clearance.teritorio.xyz`
- [ ] Verify CTA buttons in landing pages point to `app.clearance.teritorio.xyz`
- [ ] After merge to main, verify GitHub Pages serves at `clearance.teritorio.xyz`