### PR TITLE
fix(seo): disallow legacy app paths in robots.txt

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,15 @@ export default defineNuxtConfig({
     },
   },
 
+  robots: {
+    groups: [
+      {
+        userAgent: ['*'],
+        disallow: ['/api/', '/*/validators', '/*/changes_logs'],
+      },
+    ],
+  },
+
   sitemap: {
     autoLastmod: true,
   },


### PR DESCRIPTION
## Summary

- Adds `Disallow` rules for `/api/`, `/*/validators` and `/*/changes_logs` via `@nuxtjs/robots`
- These paths were indexed from a previous deployment of the app on this domain
- Prevents Googlebot from discovering new legacy URLs and reduces GSC noise

## Generated robots.txt

```
User-agent: *
Disallow: /api/
Disallow: /*/validators
Disallow: /*/changes_logs

Sitemap: https://clearance.teritorio.xyz/sitemap_index.xml
```

Closes #195