### PR TITLE
fix(seo): exclude /how-it-works index pages from sitemap

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,6 +51,7 @@ export default defineNuxtConfig({
 
   sitemap: {
     autoLastmod: true,
+    exclude: ['/fr/how-it-works', '/en/how-it-works', '/es/how-it-works'],
   },
 
   linkChecker: {


### PR DESCRIPTION
## Summary

- Adds `exclude` to `@nuxtjs/sitemap` config for `/fr/how-it-works`, `/en/how-it-works`, `/es/how-it-works`
- These pages redirect to the first sub-page and would never be indexed anyway
- Eliminates the 2 "Page with redirect" entries visible in GSC Coverage report

Closes #193