### PR TITLE
feat(content): add news/announcements section

### DIFF
--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -7,6 +7,7 @@ const footerColumns = computed(() => [
     label: t('footer.product'),
     children: [
       { label: t('nav.docs'), to: localePath('/how-it-works/replication') },
+      { label: t('nav.news'), to: localePath('/news') },
       { label: t('nav.contact'), to: localePath('/contact') },
     ],
   },

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -12,6 +12,11 @@ const navItems = computed(() => [
     to: localePath('/how-it-works/replication'),
   },
   {
+    label: t('nav.news'),
+    icon: 'i-lucide-newspaper',
+    to: localePath('/news'),
+  },
+  {
     label: t('nav.contact'),
     icon: 'i-lucide-mail',
     to: localePath('/contact'),

--- a/components/content/LandingNews.vue
+++ b/components/content/LandingNews.vue
@@ -5,6 +5,7 @@ defineProps<{
 }>()
 const { t, locale } = useI18n()
 const localePath = useLocalePath()
+const { typeColor, formatDate } = useNewsFormatting()
 
 const collectionName = computed(() => `news_${locale.value}` as 'news_fr' | 'news_en' | 'news_es')
 
@@ -17,23 +18,6 @@ const { data: news } = await useAsyncData(
       .slice(0, 3)
   },
 )
-
-function typeColor(type: string | undefined) {
-  const map: Record<string, 'primary' | 'success' | 'info'> = {
-    release: 'primary',
-    post: 'info',
-    announcement: 'success',
-  }
-  return map[type ?? 'announcement'] ?? 'primary'
-}
-
-function formatDate(date: string) {
-  return new Date(date).toLocaleDateString(locale.value, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
 </script>
 
 <template>

--- a/components/content/LandingNews.vue
+++ b/components/content/LandingNews.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+defineProps<{
+  headline?: string
+  title?: string
+}>()
+const { t, locale } = useI18n()
+const localePath = useLocalePath()
+
+const collectionName = computed(() => `news_${locale.value}` as 'news_fr' | 'news_en' | 'news_es')
+
+const { data: news } = await useAsyncData(
+  `news-latest-${locale.value}`,
+  async () => {
+    const items = await queryCollection(collectionName.value).all()
+    return items
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 3)
+  },
+)
+
+function typeColor(type: string | undefined) {
+  const map: Record<string, 'primary' | 'success' | 'info'> = {
+    release: 'primary',
+    post: 'info',
+    announcement: 'success',
+  }
+  return map[type ?? 'announcement'] ?? 'primary'
+}
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString(locale.value, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <section class="py-16 sm:py-24">
+    <UContainer>
+      <LandingSectionHeader :headline="headline" :title="title" />
+      <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <article
+          v-for="item in news"
+          :key="item.id"
+          class="flex flex-col gap-4 rounded-xl border border-default bg-default p-6"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <UBadge :color="typeColor(item.type)" variant="subtle" size="sm">
+              {{ t(`news.types.${item.type}`) }}
+            </UBadge>
+            <time :datetime="item.date" class="text-sm text-muted">
+              {{ formatDate(item.date) }}
+            </time>
+          </div>
+          <h3 class="font-semibold leading-snug">
+            {{ item.title }}
+          </h3>
+          <p class="flex-1 text-sm text-muted line-clamp-3">
+            {{ item.description }}
+          </p>
+          <UButton
+            v-if="item.url"
+            :to="item.url"
+            target="_blank"
+            rel="noopener"
+            variant="ghost"
+            size="sm"
+            trailing-icon="i-lucide-arrow-up-right"
+            class="self-start"
+          >
+            {{ t('news.readMore') }}
+          </UButton>
+        </article>
+      </div>
+      <div class="mt-10 text-center">
+        <UButton :to="localePath('/news')" variant="outline" size="lg">
+          {{ t('news.seeAll') }}
+        </UButton>
+      </div>
+    </UContainer>
+  </section>
+</template>

--- a/composables/useNewsFormatting.ts
+++ b/composables/useNewsFormatting.ts
@@ -1,0 +1,22 @@
+export function useNewsFormatting() {
+  const { locale } = useI18n()
+
+  function typeColor(type: string | undefined): 'primary' | 'success' | 'info' {
+    const map: Record<string, 'primary' | 'success' | 'info'> = {
+      release: 'primary',
+      post: 'info',
+      announcement: 'success',
+    }
+    return map[type ?? 'announcement'] ?? 'primary'
+  }
+
+  function formatDate(date: string) {
+    return new Date(date).toLocaleDateString(locale.value, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  }
+
+  return { typeColor, formatDate }
+}

--- a/content.config.ts
+++ b/content.config.ts
@@ -14,7 +14,7 @@ function defineLocaleCollection(locale: typeof locales[number]) {
 
 const newsSchema = z.object({
   title: z.string(),
-  date: z.string(),
+  date: z.preprocess(v => v instanceof Date ? v.toISOString().split('T')[0] : v, z.string()),
   description: z.string(),
   url: z.string().optional(),
   type: z.enum(['release', 'post', 'announcement']).default('announcement'),

--- a/content.config.ts
+++ b/content.config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
 
 const locales = ['en', 'fr', 'es'] as const
 
@@ -12,8 +12,25 @@ function defineLocaleCollection(locale: typeof locales[number]) {
   })
 }
 
+const newsSchema = z.object({
+  title: z.string(),
+  date: z.string(),
+  description: z.string(),
+  url: z.string().optional(),
+  type: z.enum(['release', 'post', 'announcement']).default('announcement'),
+})
+
 export default defineContentConfig({
-  collections: Object.fromEntries(
-    locales.map(locale => [`content_${locale}`, defineLocaleCollection(locale)]),
-  ),
+  collections: {
+    ...Object.fromEntries(
+      locales.map(locale => [`content_${locale}`, defineLocaleCollection(locale)]),
+    ),
+    ...Object.fromEntries(
+      locales.map(locale => [`news_${locale}`, defineCollection({
+        type: 'data',
+        source: `news/${locale}/*.yaml`,
+        schema: newsSchema,
+      })]),
+    ),
+  },
 })

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -203,6 +203,13 @@ ctaTo: https://app.clearance.teritorio.xyz/france_landes_poi/changes_logs
 
 ::
 
+::landing-news
+---
+headline: News
+title: Latest news
+---
+::
+
 ::landing-cta
 ---
 title: Open-source software

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -203,6 +203,13 @@ ctaTo: https://app.clearance.teritorio.xyz/france_landes_poi/changes_logs
 
 ::
 
+::landing-news
+---
+headline: Actualités
+title: Dernières nouvelles
+---
+::
+
 ::landing-cta
 ---
 title: Un logiciel libre

--- a/content/news/en/2026-07-07.clearance-v0-5.yaml
+++ b/content/news/en/2026-07-07.clearance-v0-5.yaml
@@ -1,5 +1,5 @@
 title: 'Clearance v0.5: a key milestone for demanding OSM data reuse'
 date: 2026-07-07
 description: 'Clearance v0.5 introduces a redesigned LoCha engine, new validators (delayed changes, invalid geometries) and filterable Atom feeds. A significant step forward for securing OpenStreetMap replication in critical contexts: emergency services, mobility operators, local authorities.'
-url: 'https://www.teritorio.fr/fr/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
+url: 'https://www.teritorio.fr/en/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
 type: release

--- a/content/news/en/2026-07-07.clearance-v0-5.yaml
+++ b/content/news/en/2026-07-07.clearance-v0-5.yaml
@@ -1,0 +1,5 @@
+title: 'Clearance v0.5: a key milestone for demanding OSM data reuse'
+date: 2026-07-07
+description: 'Clearance v0.5 introduces a redesigned LoCha engine, new validators (delayed changes, invalid geometries) and filterable Atom feeds. A significant step forward for securing OpenStreetMap replication in critical contexts: emergency services, mobility operators, local authorities.'
+url: 'https://www.teritorio.fr/fr/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
+type: release

--- a/content/news/es/2026-07-07.clearance-v0-5.yaml
+++ b/content/news/es/2026-07-07.clearance-v0-5.yaml
@@ -1,5 +1,5 @@
 title: 'Clearance v0.5: un hito clave para la reutilización exigente de datos OSM'
 date: 2026-07-07
 description: 'Clearance v0.5 presenta un motor LoCha rediseñado, nuevos validadores (cambios tardíos, geometrías inválidas) y feeds Atom filtrables. Un avance significativo para asegurar la replicación OpenStreetMap en contextos críticos: servicios de emergencia, operadores de movilidad, administraciones locales.'
-url: 'https://www.teritorio.fr/fr/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
+url: 'https://www.teritorio.fr/es/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
 type: release

--- a/content/news/es/2026-07-07.clearance-v0-5.yaml
+++ b/content/news/es/2026-07-07.clearance-v0-5.yaml
@@ -1,0 +1,5 @@
+title: 'Clearance v0.5: un hito clave para la reutilización exigente de datos OSM'
+date: 2026-07-07
+description: 'Clearance v0.5 presenta un motor LoCha rediseñado, nuevos validadores (cambios tardíos, geometrías inválidas) y feeds Atom filtrables. Un avance significativo para asegurar la replicación OpenStreetMap en contextos críticos: servicios de emergencia, operadores de movilidad, administraciones locales.'
+url: 'https://www.teritorio.fr/fr/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
+type: release

--- a/content/news/fr/2026-07-07.clearance-v0-5.yaml
+++ b/content/news/fr/2026-07-07.clearance-v0-5.yaml
@@ -1,0 +1,5 @@
+title: 'Clearance v0.5 : une étape clé pour les réutilisations exigeantes des données OSM'
+date: 2026-07-07
+description: 'Clearance v0.5 introduit un moteur LoCha revu, de nouveaux validateurs (changements tardifs, géométries invalides) et des flux Atom filtrables. Une avancée pour fiabiliser la réplication OpenStreetMap dans des contextes critiques : services de secours, mobilité, collectivités.'
+url: 'https://www.teritorio.fr/fr/blogs/clearance-v0-5-une-etape-importante-pour-fiabiliser-les-reutilisations-les-plus-exigeantes-des-donnees-openstreetmap/'
+type: release

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -41,4 +41,17 @@ export default defineI18nLocale(async () => ({
     empty: 'This page has no content yet.',
     notFound: 'Page not found',
   },
+  news: {
+    headline: 'News',
+    pageTitle: 'Latest news',
+    pageDescription: 'Follow Clearance updates: new releases, articles and announcements.',
+    seeAll: 'All news',
+    readMore: 'Read article',
+    empty: 'No news yet.',
+    types: {
+      release: 'Release',
+      post: 'Article',
+      announcement: 'Announcement',
+    },
+  },
 }))

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -3,6 +3,7 @@ export default defineI18nLocale(async () => ({
     home: 'Clearance',
     docs: 'How it works?',
     contact: 'Contact',
+    news: 'News',
     github: 'GitHub',
     seeClearance: 'See Clearance',
     changeLanguage: 'Change language',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -3,6 +3,7 @@ export default defineI18nLocale(async () => ({
     home: 'Clearance',
     docs: '¿Cómo funciona?',
     contact: 'Contacto',
+    news: 'Noticias',
     github: 'GitHub',
     seeClearance: 'Ver Clearance',
     changeLanguage: 'Cambiar idioma',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -41,4 +41,17 @@ export default defineI18nLocale(async () => ({
     empty: 'Esta página aún no tiene contenido.',
     notFound: 'Página no encontrada',
   },
+  news: {
+    headline: 'Noticias',
+    pageTitle: 'Últimas noticias',
+    pageDescription: 'Siga la evolución de Clearance: nuevas versiones, artículos y anuncios.',
+    seeAll: 'Todas las noticias',
+    readMore: 'Leer artículo',
+    empty: 'Sin noticias por el momento.',
+    types: {
+      release: 'Versión',
+      post: 'Artículo',
+      announcement: 'Anuncio',
+    },
+  },
 }))

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -3,6 +3,7 @@ export default defineI18nLocale(async () => ({
     home: 'Clearance',
     docs: 'Comment ça marche ?',
     contact: 'Contact',
+    news: 'Actualités',
     github: 'GitHub',
     seeClearance: 'Voir Clearance',
     changeLanguage: 'Changer de langue',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -41,4 +41,17 @@ export default defineI18nLocale(async () => ({
     empty: 'Cette page n\'a pas encore de contenu.',
     notFound: 'Page introuvable',
   },
+  news: {
+    headline: 'Actualités',
+    pageTitle: 'Dernières nouvelles',
+    pageDescription: 'Suivez l\'évolution de Clearance : nouvelles versions, articles et annonces.',
+    seeAll: 'Toutes les actualités',
+    readMore: 'Lire l\'article',
+    empty: 'Aucune actualité pour le moment.',
+    types: {
+      release: 'Version',
+      post: 'Article',
+      announcement: 'Annonce',
+    },
+  },
 }))

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -88,6 +88,7 @@ export default defineNuxtConfig({
       routes: ['fr', 'en', 'es'].flatMap(locale => [
         `/${locale}`,
         `/${locale}/contact`,
+        `/${locale}/news`,
         `/${locale}/how-it-works`,
         `/${locale}/how-it-works/replication`,
         `/${locale}/how-it-works/locha`,

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { t, locale } = useI18n()
+const { typeColor, formatDate } = useNewsFormatting()
 
 const collectionName = computed(() => `news_${locale.value}` as 'news_fr' | 'news_en' | 'news_es')
 
@@ -15,23 +16,6 @@ useHead({
   title: () => t('news.pageTitle'),
   meta: [{ name: 'description', content: () => t('news.pageDescription') }],
 })
-
-function typeColor(type: string | undefined) {
-  const map: Record<string, 'primary' | 'success' | 'info'> = {
-    release: 'primary',
-    post: 'info',
-    announcement: 'success',
-  }
-  return map[type ?? 'announcement'] ?? 'primary'
-}
-
-function formatDate(date: string) {
-  return new Date(date).toLocaleDateString(locale.value, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
 </script>
 
 <template>

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+const { t, locale } = useI18n()
+
+const collectionName = computed(() => `news_${locale.value}` as 'news_fr' | 'news_en' | 'news_es')
+
+const { data: news } = await useAsyncData(
+  `news-all-${locale.value}`,
+  async () => {
+    const items = await queryCollection(collectionName.value).all()
+    return items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  },
+)
+
+useHead({
+  title: () => t('news.pageTitle'),
+  meta: [{ name: 'description', content: () => t('news.pageDescription') }],
+})
+
+function typeColor(type: string | undefined) {
+  const map: Record<string, 'primary' | 'success' | 'info'> = {
+    release: 'primary',
+    post: 'info',
+    announcement: 'success',
+  }
+  return map[type ?? 'announcement'] ?? 'primary'
+}
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleDateString(locale.value, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+</script>
+
+<template>
+  <div>
+    <UContainer class="py-16 sm:py-24">
+      <div class="mb-12">
+        <p class="text-sm font-semibold text-primary uppercase tracking-wide">
+          {{ t('news.headline') }}
+        </p>
+        <h1 class="mt-2 text-3xl font-bold sm:text-4xl">
+          {{ t('news.pageTitle') }}
+        </h1>
+      </div>
+
+      <div v-if="news?.length" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <article
+          v-for="item in news"
+          :key="item.id"
+          class="flex flex-col gap-4 rounded-xl border border-default bg-default p-6"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <UBadge :color="typeColor(item.type)" variant="subtle" size="sm">
+              {{ t(`news.types.${item.type}`) }}
+            </UBadge>
+            <time :datetime="item.date" class="text-sm text-muted">
+              {{ formatDate(item.date) }}
+            </time>
+          </div>
+          <h2 class="font-semibold leading-snug">
+            {{ item.title }}
+          </h2>
+          <p class="flex-1 text-sm text-muted">
+            {{ item.description }}
+          </p>
+          <UButton
+            v-if="item.url"
+            :to="item.url"
+            target="_blank"
+            rel="noopener"
+            variant="ghost"
+            size="sm"
+            trailing-icon="i-lucide-arrow-up-right"
+            class="self-start"
+          >
+            {{ t('news.readMore') }}
+          </UButton>
+        </article>
+      </div>
+
+      <p v-else class="text-muted">
+        {{ t('news.empty') }}
+      </p>
+    </UContainer>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

- New `news_fr/en/es` data collections in `content.config.ts` (YAML schema: title, date, description, url, type)
- News files at `content/news/{locale}/` — seeded with the Clearance v0.5 release post (2026-07-07)
- `LandingNews.vue` component: fetches 3 latest entries, shows type badge + date + description + external link
- `pages/news.vue`: full listing page at `/fr/news`, `/en/news`, `/es/news`
- `::landing-news` block added to FR and EN homepages (between References and CTA sections)
- `/news` added to prerender routes
- i18n keys for FR, EN, ES

## Test plan

- [ ] Homepage `/fr` and `/en` show the news widget with the v0.5 entry
- [ ] `/fr/news` lists all entries
- [ ] Badge colors: release → amber, post → blue, announcement → green
- [ ] "Read article" links open the blog post in a new tab
- [ ] "All news" button navigates to `/fr/news`
- [ ] Works correctly in EN and ES locales

Closes #192