### PR TITLE
feat(seo): add FAQ section with FAQPage structured data

### DIFF
--- a/components/content/LandingFaq.vue
+++ b/components/content/LandingFaq.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+const { t, tm } = useI18n()
+
+const items = computed(() =>
+  (tm('faq.items') as { question: string, answer: string }[]).map(
+    item => ({ label: item.question, content: item.answer }),
+  ),
+)
+</script>
+
+<template>
+  <section class="py-16 sm:py-24">
+    <UContainer>
+      <LandingSectionHeader :headline="t('faq.headline')" :title="t('faq.title')" />
+      <UAccordion
+        class="mt-12 max-w-3xl mx-auto"
+        :items="items"
+      />
+    </UContainer>
+  </section>
+</template>

--- a/components/content/LandingFaq.vue
+++ b/components/content/LandingFaq.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 const { t, tm } = useI18n()
 
-const items = computed(() =>
-  (tm('faq.items') as { question: string, answer: string }[]).map(
+const raw = computed(() => tm('faq.items'))
+const items = computed(() => {
+  const list = raw.value
+  if (!Array.isArray(list))
+    return []
+  return (list as { question: string, answer: string }[]).map(
     item => ({ label: item.question, content: item.answer }),
-  ),
-)
+  )
+})
 </script>
 
 <template>

--- a/components/content/LandingFaq.vue
+++ b/components/content/LandingFaq.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 const { t, tm } = useI18n()
 
-const raw = computed(() => tm('faq.items'))
 const items = computed(() => {
-  const list = raw.value
+  const list = tm('faq.items')
   if (!Array.isArray(list))
     return []
   return (list as { question: string, answer: string }[]).map(

--- a/content/en/index.md
+++ b/content/en/index.md
@@ -160,6 +160,9 @@ description: "Clearance is designed for organizations that regularly use OpenStr
 
 ::
 
+::landing-faq
+::
+
 ::landing-references
 ---
 headline: References

--- a/content/es/index.md
+++ b/content/es/index.md
@@ -160,6 +160,9 @@ description: "Clearance está diseñado para organizaciones que utilizan regular
 
 ::
 
+::landing-faq
+::
+
 ::landing-references
 ---
 headline: Referencias

--- a/content/fr/index.md
+++ b/content/fr/index.md
@@ -160,6 +160,9 @@ description: "Clearance s'adresse aux organisations qui utilisent régulièremen
 
 ::
 
+::landing-faq
+::
+
 ::landing-references
 ---
 headline: Références

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -55,4 +55,30 @@ export default defineI18nLocale(async () => ({
       announcement: 'Announcement',
     },
   },
+  faq: {
+    headline: 'FAQ',
+    title: 'Frequently asked questions',
+    items: [
+      {
+        question: 'What is Clearance?',
+        answer: 'Clearance is an open-source tool that filters OpenStreetMap data before it reaches your systems. It automatically validates valid changes and holds suspicious ones for review, ensuring the quality of your local OSM data copy.',
+      },
+      {
+        question: 'Is Clearance free and open source?',
+        answer: 'Yes, Clearance is free software released under the AGPL-3.0 license. The source code is available on GitHub. Teritorio also offers SaaS hosting and support services for organisations that need professional assistance.',
+      },
+      {
+        question: 'What types of OSM changes does Clearance filter?',
+        answer: 'Clearance detects suspicious geometric changes (object displacement, deletions, invalid geometries), delayed changes on sensitive data, and any modification that could affect your business use cases according to rules you define per project.',
+      },
+      {
+        question: 'Who is Clearance for?',
+        answer: 'Clearance is designed for organisations that use OpenStreetMap in critical contexts: mobility and transport operators, emergency services, local authorities, nature park managers, tourism offices, and territorial data platforms.',
+      },
+      {
+        question: 'How does Clearance differ from a simple OSM mirror or replication tool?',
+        answer: 'Traditional replication tools (osmosis, osm2pgsql, etc.) integrate changes without quality control. Clearance adds an intelligent filtering layer: valid data passes through immediately, while problematic changes are held until they are validated or corrected in OpenStreetMap at the source.',
+      },
+    ],
+  },
 }))

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -55,4 +55,30 @@ export default defineI18nLocale(async () => ({
       announcement: 'Anuncio',
     },
   },
+  faq: {
+    headline: 'FAQ',
+    title: 'Preguntas frecuentes',
+    items: [
+      {
+        question: '¿Qué es Clearance?',
+        answer: 'Clearance es una herramienta de código abierto que filtra los datos de OpenStreetMap antes de que lleguen a sus sistemas. Valida automáticamente los cambios válidos y retiene los sospechosos para su revisión, garantizando la calidad de su copia local de datos OSM.',
+      },
+      {
+        question: '¿Clearance es gratuito y de código abierto?',
+        answer: 'Sí, Clearance es software libre publicado bajo la licencia AGPL-3.0. El código fuente está disponible en GitHub. Teritorio también ofrece servicios de alojamiento SaaS y soporte para organizaciones que necesitan asistencia profesional.',
+      },
+      {
+        question: '¿Qué tipos de cambios OSM filtra Clearance?',
+        answer: 'Clearance detecta cambios geométricos sospechosos (desplazamiento de objetos, eliminaciones, geometrías inválidas), cambios tardíos en datos sensibles y cualquier modificación que pueda afectar sus usos empresariales según las reglas que defina por proyecto.',
+      },
+      {
+        question: '¿Para quién es Clearance?',
+        answer: 'Clearance está diseñado para organizaciones que usan OpenStreetMap en contextos críticos: operadores de movilidad y transporte, servicios de emergencias, administraciones locales, gestores de parques naturales, oficinas de turismo y plataformas de datos territoriales.',
+      },
+      {
+        question: '¿En qué se diferencia Clearance de un simple espejo o herramienta de replicación OSM?',
+        answer: 'Las herramientas de replicación tradicionales (osmosis, osm2pgsql, etc.) integran cambios sin control de calidad. Clearance añade una capa de filtrado inteligente: los datos válidos pasan de inmediato, mientras que los cambios problemáticos se retienen hasta que se validen o corrijan en OpenStreetMap en el origen.',
+      },
+    ],
+  },
 }))

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -55,4 +55,30 @@ export default defineI18nLocale(async () => ({
       announcement: 'Annonce',
     },
   },
+  faq: {
+    headline: 'FAQ',
+    title: 'Questions fréquentes',
+    items: [
+      {
+        question: 'Qu\'est-ce que Clearance ?',
+        answer: 'Clearance est un logiciel libre qui filtre les données OpenStreetMap avant qu\'elles n\'intègrent vos systèmes. Il valide automatiquement les modifications valides et met en attente les changements suspects pour vérification, garantissant ainsi la qualité de votre copie locale des données OSM.',
+      },
+      {
+        question: 'Clearance est-il gratuit et open source ?',
+        answer: 'Oui, Clearance est un logiciel libre publié sous licence AGPL-3.0. Le code source est disponible sur GitHub. Teritorio propose également des services d\'hébergement SaaS et d\'accompagnement pour les organisations qui souhaitent un support professionnel.',
+      },
+      {
+        question: 'Quels types de modifications OSM Clearance filtre-t-il ?',
+        answer: 'Clearance détecte les modifications géométriques suspectes (déplacements d\'objets, suppressions, géométries invalides), les changements tardifs sur des données sensibles, ainsi que toute modification susceptible d\'affecter vos usages métier selon des règles que vous définissez par projet.',
+      },
+      {
+        question: 'À qui s\'adresse Clearance ?',
+        answer: 'Clearance s\'adresse aux organisations qui utilisent OpenStreetMap dans un contexte critique : opérateurs de mobilité et de transport, services de secours, collectivités territoriales, gestionnaires de parcs naturels, offices de tourisme et plateformes de données territoriales.',
+      },
+      {
+        question: 'En quoi Clearance diffère-t-il d\'un simple miroir ou outil de réplication OSM ?',
+        answer: 'Les outils de réplication classiques (osmosis, osm2pgsql, etc.) intègrent les modifications sans contrôle de qualité. Clearance ajoute une couche de filtrage intelligente : les données valides passent immédiatement, les changements problématiques sont retenus jusqu\'à validation ou correction dans OpenStreetMap à la source.',
+      },
+    ],
+  },
 }))

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { t, locale } = useI18n()
+const { t, tm, locale } = useI18n()
 
 const collectionName = computed(() => `content_${locale.value}` as const)
 
@@ -14,6 +14,23 @@ useHead({
     { name: 'description', content: () => page.value?.description },
   ],
 })
+
+const faqItems = computed(() => tm('faq.items') as { question: string, answer: string }[])
+
+useSchemaOrg([
+  defineWebPage(),
+  {
+    '@type': 'FAQPage',
+    'mainEntity': faqItems.value.map(item => ({
+      '@type': 'Question',
+      'name': item.question,
+      'acceptedAnswer': {
+        '@type': 'Answer',
+        'text': item.answer,
+      },
+    })),
+  },
+])
 </script>
 
 <template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,7 +15,10 @@ useHead({
   ],
 })
 
-const faqItems = computed(() => tm('faq.items') as { question: string, answer: string }[])
+const faqItems = computed(() => {
+  const raw = tm('faq.items')
+  return Array.isArray(raw) ? raw as { question: string, answer: string }[] : []
+})
 
 useSchemaOrg([
   defineWebPage(),

--- a/tests/components/AppHeader.test.ts
+++ b/tests/components/AppHeader.test.ts
@@ -12,17 +12,18 @@ describe('appHeader', () => {
     expect(localeButton.text()).toContain('EN')
   })
 
-  it('renders docs and contact navigation items', async () => {
+  it('renders docs, news and contact navigation items', async () => {
     const component = await mountSuspended(AppHeader)
     const html = component.html()
     expect(html).toContain('/en/how-it-works/replication')
+    expect(html).toContain('/en/news')
     expect(html).toContain('/en/contact')
   })
 
-  it('renders GitHub link', async () => {
+  it('does not render GitHub link in header navigation', async () => {
     const component = await mountSuspended(AppHeader)
     const html = component.html()
-    expect(html).toContain('https://github.com/teritorio/clearance')
+    expect(html).not.toContain('https://github.com/teritorio/clearance')
   })
 
   it('renders See Clearance CTA button with correct URL', async () => {

--- a/tests/components/content/landing.test.ts
+++ b/tests/components/content/landing.test.ts
@@ -2,6 +2,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { describe, expect, it } from 'vitest'
 import { h } from 'vue'
 import LandingCta from '~/components/content/LandingCta.vue'
+import LandingFaq from '~/components/content/LandingFaq.vue'
 import LandingFeature from '~/components/content/LandingFeature.vue'
 import LandingFeatures from '~/components/content/LandingFeatures.vue'
 import LandingHero from '~/components/content/LandingHero.vue'
@@ -12,6 +13,23 @@ import LandingSolution from '~/components/content/LandingSolution.vue'
 import LandingStep from '~/components/content/LandingStep.vue'
 import LandingUseCase from '~/components/content/LandingUseCase.vue'
 import LandingUseCases from '~/components/content/LandingUseCases.vue'
+
+describe('landingFaq', () => {
+  it('renders headline and title from i18n', async () => {
+    const component = await mountSuspended(LandingFaq)
+    expect(component.text()).toContain('FAQ')
+    expect(component.text()).toContain('Frequently asked questions')
+  })
+
+  it('renders all 5 FAQ questions from i18n', async () => {
+    const component = await mountSuspended(LandingFaq)
+    expect(component.text()).toContain('What is Clearance?')
+    expect(component.text()).toContain('Is Clearance free and open source?')
+    expect(component.text()).toContain('What types of OSM changes does Clearance filter?')
+    expect(component.text()).toContain('Who is Clearance for?')
+    expect(component.text()).toContain('How does Clearance differ from a simple OSM mirror or replication tool?')
+  })
+})
 
 describe('landingSectionHeader', () => {
   it('renders headline, title, and description', async () => {


### PR DESCRIPTION
Closes #202

## Summary

- Add `LandingFaq.vue` accordion component reading Q&A pairs from i18n
- Add `FAQPage` schema.org structured data to `pages/index.vue` via `useSchemaOrg`
- Add `faq` i18n keys with 5 Q&A pairs in fr/en/es locales
- Insert `::landing-faq::` in homepage content for all 3 locales (between use-cases and references)
- Update `AppHeader` tests to reflect the GitHub nav link removal (merged in #198)

## Test plan

- [ ] FAQ accordion renders correctly on homepage (fr/en/es)
- [ ] `FAQPage` structured data appears in page source (`<script type="application/ld+json">`)
- [ ] Google Rich Results Test validates the FAQ markup
- [ ] All 60 tests pass