### PR TITLE
feat(seo): add seoTitle field to enrich meta titles per page

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -9,6 +9,9 @@ function defineLocaleCollection(locale: typeof locales[number]) {
       include: `${locale}/**`,
       prefix: `/${locale}`,
     },
+    schema: z.object({
+      seoTitle: z.string().optional(),
+    }),
   })
 }
 

--- a/content/en/1.how-it-works/1.replication.md
+++ b/content/en/1.how-it-works/1.replication.md
@@ -1,5 +1,6 @@
 ---
 title: OSM Replication
+seoTitle: "OpenStreetMap Replication with Quality Filtering"
 description: "Clearance implements an OpenStreetMap replication under quality constraints: a controlled and partially synchronized local copy."
 icon: i-lucide-refresh-cw
 ---

--- a/content/en/1.how-it-works/2.locha.md
+++ b/content/en/1.how-it-works/2.locha.md
@@ -1,5 +1,6 @@
 ---
 title: Local Changesets (LoCha)
+seoTitle: "Local Changesets (LoCha) — Contextual Validation"
 description: "Clearance groups OSM changes into geographically coherent sets (LoCha) before semantic validation, rather than OSM object by object."
 icon: i-lucide-map-pin
 ---

--- a/content/en/1.how-it-works/3.semantic.md
+++ b/content/en/1.how-it-works/3.semantic.md
@@ -1,5 +1,6 @@
 ---
 title: Semantic Conflation
+seoTitle: "Semantic Conflation and Business-level Validation"
 description: "Clearance reconstructs a semantic history of business objects from OSM objects, to make validation at the business level, not at the technical level."
 icon: i-lucide-brain
 ---

--- a/content/en/1.how-it-works/4.rules.md
+++ b/content/en/1.how-it-works/4.rules.md
@@ -1,6 +1,6 @@
 ---
 title: Control Rules
-seoTitle: "Control Rules and Validators in Clearance"
+seoTitle: "Control Rules — Quality Validators for OSM"
 description: "Clearance's validators: delayed, deleted, duplicate, geom, network, tags, and user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/en/1.how-it-works/4.rules.md
+++ b/content/en/1.how-it-works/4.rules.md
@@ -1,5 +1,6 @@
 ---
 title: Control Rules
+seoTitle: "Control Rules and Validators in Clearance"
 description: "Clearance's validators: delayed, deleted, duplicate, geom, network, tags, and user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/en/1.how-it-works/5.feedback-loop.md
+++ b/content/en/1.how-it-works/5.feedback-loop.md
@@ -1,5 +1,6 @@
 ---
 title: Feedback Loop
+seoTitle: "Feedback Loop — Corrections and Change Acceptance"
 description: "The correction and acceptance cycle for changes in Clearance: correction in OSM or manual acceptance."
 icon: i-lucide-repeat
 ---

--- a/content/en/1.how-it-works/6.roadmap.md
+++ b/content/en/1.how-it-works/6.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-seoTitle: "Clearance Roadmap — Upcoming Features"
+seoTitle: "Roadmap — Upcoming Features and Improvements"
 description: "Upcoming developments for Clearance: cross-referencing with external sources, external quality rules, and contributor reputation."
 icon: i-lucide-compass
 ---

--- a/content/en/1.how-it-works/6.roadmap.md
+++ b/content/en/1.how-it-works/6.roadmap.md
@@ -1,5 +1,6 @@
 ---
 title: Roadmap
+seoTitle: "Clearance Roadmap — Upcoming Features"
 description: "Upcoming developments for Clearance: cross-referencing with external sources, external quality rules, and contributor reputation."
 icon: i-lucide-compass
 ---

--- a/content/en/contact.md
+++ b/content/en/contact.md
@@ -1,4 +1,5 @@
 ---
 title: "Contact"
+seoTitle: "Contact us for a demo or expert support"
 description: "Contact the Clearance team for a demo, support, or any question about the quality filter for OpenStreetMap replication."
 ---

--- a/content/es/1.how-it-works/1.replication.md
+++ b/content/es/1.how-it-works/1.replication.md
@@ -1,5 +1,6 @@
 ---
 title: Replicación OSM
+seoTitle: "Replicación OpenStreetMap con filtro de calidad"
 description: "Clearance implementa una replicación de OpenStreetMap bajo restricciones de calidad: una copia local controlada y parcialmente sincronizada."
 icon: i-lucide-refresh-cw
 ---

--- a/content/es/1.how-it-works/2.locha.md
+++ b/content/es/1.how-it-works/2.locha.md
@@ -1,5 +1,6 @@
 ---
 title: Cambios locales (LoCha)
+seoTitle: "Changesets locales (LoCha) — Validación contextual"
 description: "Clearance agrupa los cambios OSM en conjuntos geográficamente coherentes (LoCha) para una validación contextual, y no objeto por objeto."
 icon: i-lucide-map-pin
 ---

--- a/content/es/1.how-it-works/3.semantic.md
+++ b/content/es/1.how-it-works/3.semantic.md
@@ -1,5 +1,6 @@
 ---
 title: Reconciliación semántica
+seoTitle: "Reconciliación semántica — Validación a nivel negocio"
 description: "Clearance reconstruye un historial semántico de los objetos de trabajo desde los objetos OSM, para validar los cambios a nivel de negocio, y no al nivel técnico."
 icon: i-lucide-brain
 ---

--- a/content/es/1.how-it-works/4.rules.md
+++ b/content/es/1.how-it-works/4.rules.md
@@ -1,5 +1,6 @@
 ---
 title: Reglas de control
+seoTitle: "Reglas de control y validadores de Clearance"
 description: "Los validadores de Clearance: delayed, deleted, duplicate, geom, network, tags y user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/es/1.how-it-works/4.rules.md
+++ b/content/es/1.how-it-works/4.rules.md
@@ -1,6 +1,6 @@
 ---
 title: Reglas de control
-seoTitle: "Reglas de control y validadores de Clearance"
+seoTitle: "Reglas de control — Validadores de calidad OSM"
 description: "Los validadores de Clearance: delayed, deleted, duplicate, geom, network, tags y user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/es/1.how-it-works/5.feedback-loop.md
+++ b/content/es/1.how-it-works/5.feedback-loop.md
@@ -1,5 +1,6 @@
 ---
 title: Bucle de mejora
+seoTitle: "Bucle de mejora — Correcciones y aceptación de cambios"
 description: "El ciclo de corrección y aceptación de cambios en Clearance: corrección en OSM o aceptación manual."
 icon: i-lucide-repeat
 ---

--- a/content/es/1.how-it-works/6.roadmap.md
+++ b/content/es/1.how-it-works/6.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Hoja de ruta
-seoTitle: "Hoja de ruta de Clearance — Próximas evoluciones"
+seoTitle: "Hoja de ruta — Próximas evoluciones y funciones"
 description: "Las próximas evoluciones de Clearance: cruce con fuentes externas, reglas de calidad externas y reputación de los contribuidores."
 icon: i-lucide-compass
 ---

--- a/content/es/1.how-it-works/6.roadmap.md
+++ b/content/es/1.how-it-works/6.roadmap.md
@@ -1,5 +1,6 @@
 ---
 title: Hoja de ruta
+seoTitle: "Hoja de ruta de Clearance — Próximas evoluciones"
 description: "Las próximas evoluciones de Clearance: cruce con fuentes externas, reglas de calidad externas y reputación de los contribuidores."
 icon: i-lucide-compass
 ---

--- a/content/es/contact.md
+++ b/content/es/contact.md
@@ -1,4 +1,5 @@
 ---
 title: "Contacto"
+seoTitle: "Contáctenos para una demo o asesoramiento experto"
 description: "Contacte al equipo de Clearance para una demo, asistencia o cualquier pregunta sobre el filtro de calidad para la replicación OpenStreetMap."
 ---

--- a/content/fr/1.how-it-works/1.replication.md
+++ b/content/fr/1.how-it-works/1.replication.md
@@ -1,5 +1,6 @@
 ---
 title: Réplication OSM
+seoTitle: "Réplication OpenStreetMap avec filtre qualité"
 description: "Clearance met en œuvre une réplication d'OpenStreetMap sous contraintes de qualité : une copie locale contrôlée et partiellement synchronisée."
 icon: i-lucide-refresh-cw
 ---

--- a/content/fr/1.how-it-works/2.locha.md
+++ b/content/fr/1.how-it-works/2.locha.md
@@ -1,5 +1,6 @@
 ---
 title: Changements locaux (LoCha)
+seoTitle: "Changesets locaux LoCha — Validation contextuelle"
 description: "Clearance regroupe les changements OSM en ensembles géographiquement cohérents (LoCha) pour une validation contextuelle, et non objet par objet."
 icon: i-lucide-map-pin
 ---

--- a/content/fr/1.how-it-works/2.locha.md
+++ b/content/fr/1.how-it-works/2.locha.md
@@ -1,6 +1,6 @@
 ---
 title: Changements locaux (LoCha)
-seoTitle: "Changesets locaux LoCha — Validation contextuelle"
+seoTitle: "Changements locaux LoCha — Validation contextuelle"
 description: "Clearance regroupe les changements OSM en ensembles géographiquement cohérents (LoCha) pour une validation contextuelle, et non objet par objet."
 icon: i-lucide-map-pin
 ---

--- a/content/fr/1.how-it-works/3.semantic.md
+++ b/content/fr/1.how-it-works/3.semantic.md
@@ -1,5 +1,6 @@
 ---
 title: Rapprochement sémantique
+seoTitle: "Rapprochement sémantique — Validation métier OSM"
 description: "Clearance reconstruit un historique sémantique des objets métiers depuis les objets OSM, pour valider les changements au niveau métier, et non pas au niveau technique."
 icon: i-lucide-brain
 ---

--- a/content/fr/1.how-it-works/4.rules.md
+++ b/content/fr/1.how-it-works/4.rules.md
@@ -1,6 +1,6 @@
 ---
 title: Règles de contrôle
-seoTitle: "Règles de contrôle et validateurs Clearance"
+seoTitle: "Règles de contrôle — Validateurs qualité OSM"
 description: "Les validateurs de Clearance : delayed, deleted, duplicate, geom, network, tags et user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/fr/1.how-it-works/4.rules.md
+++ b/content/fr/1.how-it-works/4.rules.md
@@ -1,5 +1,6 @@
 ---
 title: Règles de contrôle
+seoTitle: "Règles de contrôle et validateurs Clearance"
 description: "Les validateurs de Clearance : delayed, deleted, duplicate, geom, network, tags et user_list."
 icon: i-lucide-list-checks
 ---

--- a/content/fr/1.how-it-works/5.feedback-loop.md
+++ b/content/fr/1.how-it-works/5.feedback-loop.md
@@ -1,5 +1,6 @@
 ---
 title: Boucle d'amélioration
+seoTitle: "Boucle de correction des changements OSM retenus"
 description: "Le cycle de correction et d'acceptation des changements dans Clearance : correction dans OSM ou acceptation manuelle."
 icon: i-lucide-repeat
 ---

--- a/content/fr/1.how-it-works/6.roadmap.md
+++ b/content/fr/1.how-it-works/6.roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Feuille de route
-seoTitle: "Feuille de route Clearance — Évolutions à venir"
+seoTitle: "Feuille de route — Évolutions à venir"
 description: "Les évolutions à venir pour Clearance : croisement avec des sources externes, règles de qualité externes et réputation des contributeurs."
 icon: i-lucide-compass
 ---

--- a/content/fr/1.how-it-works/6.roadmap.md
+++ b/content/fr/1.how-it-works/6.roadmap.md
@@ -1,5 +1,6 @@
 ---
 title: Feuille de route
+seoTitle: "Feuille de route Clearance — Évolutions à venir"
 description: "Les évolutions à venir pour Clearance : croisement avec des sources externes, règles de qualité externes et réputation des contributeurs."
 icon: i-lucide-compass
 ---

--- a/content/fr/contact.md
+++ b/content/fr/contact.md
@@ -1,4 +1,5 @@
 ---
 title: "Contact"
+seoTitle: "Contactez-nous pour une démo ou un accompagnement"
 description: "Contactez l'équipe Clearance pour une démo, un accompagnement ou toute question sur le filtre qualité pour la réplication OpenStreetMap."
 ---

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -45,7 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'News',
     pageTitle: 'Latest news',
-    seoTitle: 'Clearance News — Releases, Articles and Announcements',
+    seoTitle: 'News — Releases, Articles and Announcements',
     pageDescription: 'Follow Clearance updates: new releases, articles and announcements.',
     seeAll: 'All news',
     readMore: 'Read article',

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -45,6 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'News',
     pageTitle: 'Latest news',
+    seoTitle: 'Clearance News — Releases, Articles and Announcements',
     pageDescription: 'Follow Clearance updates: new releases, articles and announcements.',
     seeAll: 'All news',
     readMore: 'Read article',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -45,6 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'Noticias',
     pageTitle: 'Últimas noticias',
+    seoTitle: 'Noticias de Clearance — Versiones, artículos y anuncios',
     pageDescription: 'Siga la evolución de Clearance: nuevas versiones, artículos y anuncios.',
     seeAll: 'Todas las noticias',
     readMore: 'Leer artículo',

--- a/i18n/locales/es.ts
+++ b/i18n/locales/es.ts
@@ -45,7 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'Noticias',
     pageTitle: 'Últimas noticias',
-    seoTitle: 'Noticias de Clearance — Versiones, artículos y anuncios',
+    seoTitle: 'Noticias — Versiones, artículos y anuncios',
     pageDescription: 'Siga la evolución de Clearance: nuevas versiones, artículos y anuncios.',
     seeAll: 'Todas las noticias',
     readMore: 'Leer artículo',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -45,6 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'Actualités',
     pageTitle: 'Dernières nouvelles',
+    seoTitle: 'Actualités Clearance — Versions, articles et annonces',
     pageDescription: 'Suivez l\'évolution de Clearance : nouvelles versions, articles et annonces.',
     seeAll: 'Toutes les actualités',
     readMore: 'Lire l\'article',

--- a/i18n/locales/fr.ts
+++ b/i18n/locales/fr.ts
@@ -45,7 +45,7 @@ export default defineI18nLocale(async () => ({
   news: {
     headline: 'Actualités',
     pageTitle: 'Dernières nouvelles',
-    seoTitle: 'Actualités Clearance — Versions, articles et annonces',
+    seoTitle: 'Actualités — Versions, articles et annonces',
     pageDescription: 'Suivez l\'évolution de Clearance : nouvelles versions, articles et annonces.',
     seeAll: 'Toutes les actualités',
     readMore: 'Lire l\'article',

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -62,7 +62,7 @@ const surround = computed(() => {
 })
 
 useHead({
-  title: () => page.value?.title,
+  title: () => page.value?.seoTitle ?? page.value?.title,
   meta: [
     { name: 'description', content: () => page.value?.description },
   ],

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -9,7 +9,7 @@ const { data: page } = await useAsyncData(
 )
 
 useHead({
-  title: () => page.value?.title,
+  title: () => page.value?.seoTitle ?? page.value?.title,
   meta: [
     { name: 'description', content: () => page.value?.description },
   ],

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@ const { data: page } = await useAsyncData(
 )
 
 useHead({
-  title: () => page.value?.title,
+  title: () => page.value?.seoTitle ?? page.value?.title,
   meta: [
     { name: 'description', content: () => page.value?.description },
   ],

--- a/pages/news.vue
+++ b/pages/news.vue
@@ -13,7 +13,7 @@ const { data: news } = await useAsyncData(
 )
 
 useHead({
-  title: () => t('news.pageTitle'),
+  title: () => t('news.seoTitle'),
   meta: [{ name: 'description', content: () => t('news.pageDescription') }],
 })
 </script>


### PR DESCRIPTION
## Summary

Closes #201

- Adds a `seoTitle` optional frontmatter field to all page collections (via `content.config.ts` schema extension).
- `pages/[...slug].vue`, `pages/contact.vue`, and `pages/index.vue` now use `seoTitle ?? title` so the SEO title and the navigation/sidebar label can differ.
- `pages/news.vue` uses a new `news.seoTitle` i18n key for `<title>` (separate from `news.pageTitle` used in the visible H1).
- Adds `seoTitle` to `content/{fr,en,es}/contact.md` (3 files).
- Adds `seoTitle` to all 6 how-it-works pages across fr/en/es (18 files), covering: replication, locha, semantic, rules, feedback-loop, roadmap.

## Test plan

- [ ] Run `pnpm test:run` — all 63 tests pass
- [ ] Run `pnpm typecheck` — no errors
- [ ] Check `<title>` in browser on `/fr/1.how-it-works/1.replication` → "Réplication OpenStreetMap avec filtre qualité | Clearance"
- [ ] Check `<title>` on `/fr/contact` → "Contactez-nous pour une démo ou un accompagnement | Clearance"
- [ ] Check `<title>` on `/fr/news` → "Actualités Clearance — Versions, articles et annonces | Clearance"
- [ ] Confirm sidebar/nav still shows short `title` values (UI unaffected)