### PR TITLE
fix(seo): add static root redirect to fix 404 for bots and crawlers

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -67,6 +67,7 @@ export default defineNuxtConfig({
     baseUrl: 'https://clearance.teritorio.xyz',
     strategy: 'prefix',
     defaultLocale: 'fr',
+    rootRedirect: 'fr',
     langDir: 'locales',
     locales: [
       { code: 'en', name: 'English', language: 'en-US', file: 'en.ts' },

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=/fr/">
+    <link rel="canonical" href="https://clearance.teritorio.xyz/fr/">
+    <title>Clearance</title>
+  </head>
+  <body>
+    <a href="/fr/">Clearance</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Root URL `https://clearance.teritorio.xyz/` returned HTTP 404 on GitHub Pages — Nuxt i18n `strategy: "prefix"` generates no `index.html` at the site root
- The redirect to `/fr` was purely JavaScript, making the site unreachable for AI crawlers (ClaudeBot, GPTBot) and no-JS bots
- Adds `public/index.html` with a `<meta http-equiv="refresh">` redirect to `/fr/` — GitHub Pages serves this file directly, returning HTTP 200
- Also sets `rootRedirect: "fr"` in the i18n config as belt-and-suspenders for the Nuxt client-side router

## Test plan

- [ ] `pnpm generate` → `.output/public/index.html` exists at the root with the meta refresh to `/fr/`
- [ ] Visiting `https://clearance.teritorio.xyz/` in a browser redirects to `/fr/`
- [ ] `curl -I https://clearance.teritorio.xyz/` returns HTTP 200 (not 404) after deploy

Closes #210