### PR TITLE
fix(navigation): fix client-side navigation with reactive useAsyncData keys

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -4,7 +4,6 @@ import { en, es, fr } from '@nuxt/ui/locale'
 const uiLocales: Record<string, typeof en> = { en, fr, es }
 
 const { t, locale } = useI18n()
-const route = useRoute()
 const uiLocale = computed(() => uiLocales[locale.value] || en)
 
 useSeoMeta({
@@ -34,7 +33,7 @@ useSchemaOrg([
 <template>
   <UApp :locale="uiLocale">
     <NuxtLayout>
-      <NuxtPage :page-key="route.path" />
+      <NuxtPage :page-key="locale" />
     </NuxtLayout>
   </UApp>
 </template>

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -11,7 +11,7 @@ const path = computed(() => {
 })
 
 const { data: page } = await useAsyncData(
-  `slug-${locale.value}-${slug.value.join('/')}`,
+  () => `slug-${locale.value}-${slug.value.join('/')}`,
   () => queryCollection(collectionName.value).path(path.value).first(),
 )
 
@@ -20,9 +20,8 @@ if (!page.value) {
 }
 
 const { data: navigation } = await useAsyncData(
-  `navigation-${locale.value}`,
+  () => `navigation-${locale.value}`,
   () => queryCollectionNavigation(collectionName.value),
-  { watch: [locale] },
 )
 
 const docsSections = computed(() => extractDocsSections(navigation.value ?? []))
@@ -34,7 +33,7 @@ const sectionSlug = computed<string | undefined>(() => {
 })
 
 const { data: sectionIndex } = await useAsyncData(
-  `breadcrumb-section-${locale.value}-${sectionSlug.value ?? ''}`,
+  () => `breadcrumb-section-${locale.value}-${sectionSlug.value ?? ''}`,
   () => {
     const section = sectionSlug.value
     return section
@@ -44,7 +43,7 @@ const { data: sectionIndex } = await useAsyncData(
 )
 
 const { data: rawSurround } = await useAsyncData(
-  `surround-${locale.value}-${slug.value.join('/')}`,
+  () => `surround-${locale.value}-${slug.value.join('/')}`,
   () => isDocsPage.value
     ? queryCollectionItemSurroundings(collectionName.value, path.value, { before: 2, after: 2 })
     : Promise.resolve(null),

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -10,7 +10,7 @@ const path = computed(() => {
   return `/${locale.value}/${slug.value.join('/')}`
 })
 
-const { data: page } = await useAsyncData(
+const { data: page, status: pageStatus } = await useAsyncData(
   () => `slug-${locale.value}-${slug.value.join('/')}`,
   () => queryCollection(collectionName.value).path(path.value).first(),
 )
@@ -18,6 +18,12 @@ const { data: page } = await useAsyncData(
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 }
+
+watch(pageStatus, (status) => {
+  if (status === 'success' && !page.value) {
+    showError({ statusCode: 404, statusMessage: 'Page not found' })
+  }
+})
 
 const { data: navigation } = await useAsyncData(
   () => `navigation-${locale.value}`,


### PR DESCRIPTION
Closes #213

## Root cause

`app.vue` used `:page-key="route.path"` which forced `[...slug].vue` to be destroyed and recreated on every navigation. Since `[...slug].vue` contains `<NuxtLayout name="docs">`, this also destroyed and recreated `docs.vue` via `NuxtLayoutProvider`. The slot content from the new `[...slug].vue` instance failed to propagate correctly into the new `docs.vue` during the Suspense transition — resulting in the sidebar remaining visible but the main content not updating.

Additionally, the `useAsyncData` keys were static strings computed once at component setup. Even though the component was being recreated, the async data mechanism had subtle timing issues with the Suspense boundary and KeepAlive that prevented content updates.

## Fix

**`app.vue`**: Change `page-key` from `route.path` to `locale`.
- `[...slug].vue` now persists across navigation within the same locale.
- It is only recreated on language switch, which is the correct time to reset state (forces fresh `docs.vue` setup with the new locale's navigation data).

**`pages/[...slug].vue`**: Change all `useAsyncData` keys from static strings to reactive function form (`() => 'key-...'`).
- Nuxt 4 tracks reactive dependencies inside the key function. When `slug` or `locale` changes, the key function returns a different string, triggering a data refresh.
- The component (`[...slug].vue`) stays alive; only the reactive data updates, which Vue re-renders in-place.
- Removed the redundant `watch: [locale]` option from the navigation query (now handled by the reactive key function).

## Behaviour after fix

- Clicking sidebar links updates the main content immediately.
- Next/prev buttons work on the first click.
- The sidebar and accordion state persist across navigation (no unnecessary remounts).
- Language switch still correctly resets the page component.